### PR TITLE
refactor: motor de análisis compartido entre CLI, web y GUI

### DIFF
--- a/analyzer/__init__.py
+++ b/analyzer/__init__.py
@@ -1,0 +1,4 @@
+"""Shared analysis engine, used by the CLI, the web backend and the GUI.
+
+Standard library only: the CLI must keep working without any pip install.
+"""

--- a/analyzer/cache_types.py
+++ b/analyzer/cache_types.py
@@ -32,14 +32,24 @@ ALL_LABELS = (
 # Categories safe to delete without human review. Downloads holds user data and
 # GENERAL is by definition unclassified, so neither is ever auto-cleanable.
 #
-# This is an exact translation of the CLI's pre-unification clean_cache
-# safelist ({'Logs del Sistema', 'VS Code', 'Node.js/npm', 'Xcode Development',
-# 'Python Cache'}) to the unified label set -- same five categories, no more,
-# no fewer. In particular TEMP ('Archivos Temporales') is deliberately
-# excluded: it's a core-only category the old CLI safelist never included, and
-# adding a new category to a safelist that deletes files is a behavior change
-# that must not happen silently as a side effect of this refactor.
-SAFE_TO_CLEAN = frozenset({LOGS, VSCODE, NPM, XCODE, PYTHON})
+# This restores true behavioral parity with what the old CLI actually DID,
+# not with what its dead safelist text said. The pre-unification clean_cache
+# safelist was {'Logs del Sistema', 'VS Code', 'Node.js/npm',
+# 'Xcode Development', 'Python Cache'} -- but the old CLI's classify_cache
+# had no python-specific branch, so it never produced 'Python Cache' for
+# anything; python paths always fell through to 'Cache General' and were
+# never cleaned. Now that PYTHON is a real, reachable label (from the
+# unified classifier), including it here would newly enable actual deletion
+# of python caches -- and clean_cache's directory branch does a permanent
+# rglob().unlink(), not a move to Trash (see task-4-report.md, "Fix round
+# 1"), so this would be irreversible. That's a real behavior change and is
+# deliberately deferred to an explicit owner decision, not introduced as a
+# side effect of this refactor. Do not add PYTHON back without that decision
+# -- see the test that pins its absence in tests/test_cache_labels.py.
+#
+# TEMP ('Archivos Temporales') is excluded for the same reason: it's a
+# core-only category the old CLI safelist never included at all.
+SAFE_TO_CLEAN = frozenset({LOGS, VSCODE, NPM, XCODE})
 
 
 def classify(path: Path) -> str:
@@ -51,8 +61,13 @@ def classify(path: Path) -> str:
     Cache and leave the Xcode branch unreachable. This was a real bug in
     DiskAnalyzerCore.categorize_cache prior to unification (see
     task-4-report.md); fixed here by moving the more specific pattern first.
-    All other branch precedence is preserved verbatim from the core's
-    original categorize_cache.
+    The relative order of the other 11 branches is preserved verbatim from
+    the core's original categorize_cache. Note this is NOT a no-op for every
+    path, though: a path matching both 'xcode' and a later keyword (e.g. an
+    Xcode project with node_modules copied into DerivedData, matching both
+    'xcode' and 'node') now resolves to XCODE where the pre-fix code would
+    have hit that later branch (e.g. NPM) instead. Only single-keyword paths
+    are guaranteed unaffected by moving 'xcode' to the front.
     """
     path_str = str(path).lower()
 

--- a/analyzer/cache_types.py
+++ b/analyzer/cache_types.py
@@ -1,0 +1,82 @@
+"""Cache category labels and classification.
+
+These label strings are a contract: the classifier produces them, and
+generate_recommendations (CLI and core), clean_cache's safelist and the web
+cleanup endpoint all match on them. Changing a string without updating every
+consumer silently disables a cleanup feature.
+
+Ported from DiskAnalyzerCore.categorize_cache (disk_analyzer_core.py), which
+both DiskAnalyzer.classify_cache (CLI) and DiskAnalyzerCore.categorize_cache
+now delegate to (Task 4 of the shared-engine refactor).
+"""
+from pathlib import Path
+
+DOCKER = 'Docker'
+XCODE = 'Xcode Cache'
+VSCODE = 'VS Code Cache'
+NPM = 'NPM Cache'
+PYTHON = 'Python Cache'
+CHROME = 'Chrome Cache'
+FIREFOX = 'Firefox Cache'
+TRASH = 'Papelera'
+TEMP = 'Archivos Temporales'
+LOGS = 'Logs del Sistema'
+DOWNLOADS = 'Downloads'
+GENERAL = 'Cache General'
+
+ALL_LABELS = (
+    DOCKER, XCODE, VSCODE, NPM, PYTHON, CHROME, FIREFOX,
+    TRASH, TEMP, LOGS, DOWNLOADS, GENERAL,
+)
+
+# Categories safe to delete without human review. Downloads holds user data and
+# GENERAL is by definition unclassified, so neither is ever auto-cleanable.
+#
+# This is an exact translation of the CLI's pre-unification clean_cache
+# safelist ({'Logs del Sistema', 'VS Code', 'Node.js/npm', 'Xcode Development',
+# 'Python Cache'}) to the unified label set -- same five categories, no more,
+# no fewer. In particular TEMP ('Archivos Temporales') is deliberately
+# excluded: it's a core-only category the old CLI safelist never included, and
+# adding a new category to a safelist that deletes files is a behavior change
+# that must not happen silently as a side effect of this refactor.
+SAFE_TO_CLEAN = frozenset({LOGS, VSCODE, NPM, XCODE, PYTHON})
+
+
+def classify(path: Path) -> str:
+    """Classify a cache location by path. Order matters: first match wins.
+
+    'xcode' is checked before 'code'/'vscode' -- "xcode" contains the
+    substring "code", so checking the VS Code pattern first would make every
+    Xcode path (e.g. .../Library/Developer/Xcode/DerivedData) match VS Code
+    Cache and leave the Xcode branch unreachable. This was a real bug in
+    DiskAnalyzerCore.categorize_cache prior to unification (see
+    task-4-report.md); fixed here by moving the more specific pattern first.
+    All other branch precedence is preserved verbatim from the core's
+    original categorize_cache.
+    """
+    path_str = str(path).lower()
+
+    if 'xcode' in path_str:
+        return XCODE
+    elif 'code' in path_str or 'vscode' in path_str:
+        return VSCODE
+    elif 'chrome' in path_str:
+        return CHROME
+    elif 'firefox' in path_str or 'mozilla' in path_str:
+        return FIREFOX
+    elif 'npm' in path_str or 'node' in path_str:
+        return NPM
+    elif 'pip' in path_str or 'python' in path_str:
+        return PYTHON
+    elif 'docker' in path_str:
+        return DOCKER
+    elif 'trash' in path_str or 'recycle' in path_str:
+        return TRASH
+    elif 'temp' in path_str or 'tmp' in path_str:
+        return TEMP
+    elif 'log' in path_str:
+        return LOGS
+    elif 'download' in path_str:
+        return DOWNLOADS
+    else:
+        return GENERAL

--- a/analyzer/constants.py
+++ b/analyzer/constants.py
@@ -1,0 +1,121 @@
+"""Shared constants for the disk analysis engine.
+
+Moved verbatim from disk_analyzer.py / disk_analyzer_core.py, which used to
+define the same values twice. Standard library only.
+"""
+
+import platform
+
+# Configuración de tamaños
+KB = 1024
+MB = KB * 1024
+GB = MB * 1024
+
+# Detección del sistema operativo
+SYSTEM = platform.system()
+IS_WINDOWS = SYSTEM == 'Windows'
+IS_MACOS = SYSTEM == 'Darwin'
+IS_LINUX = SYSTEM == 'Linux'
+
+# Directorios típicos con archivos temporales o cache por sistema
+if IS_WINDOWS:
+    CACHE_DIRS = [
+        "~/AppData/Local/Temp",
+        "~/AppData/Local/Microsoft/Windows/INetCache",
+        "~/AppData/Local/Microsoft/Windows/Explorer",
+        "~/AppData/Roaming/Code/Cache",
+        "~/AppData/Roaming/Code/CachedData",
+        "~/AppData/Local/Google/Chrome/User Data/Default/Cache",
+        "~/AppData/Local/Mozilla/Firefox/Profiles",
+        "~/.npm",
+        "~/.cache",
+        "~/Downloads",
+        "$RECYCLE.BIN",
+        "C:/Windows/Temp",
+        "~/AppData/Local/Docker",
+        "~/.docker",
+    ]
+elif IS_MACOS:
+    CACHE_DIRS = [
+        "~/Library/Caches",
+        "~/Library/Logs",
+        "~/Library/Application Support/Code/Cache",
+        "~/Library/Application Support/Code/CachedData",
+        "~/Library/Developer/Xcode/DerivedData",
+        "~/Library/Developer/Xcode/Archives",
+        "~/Library/Developer/CoreSimulator/Devices",
+        "~/.npm",
+        "~/.cache",
+        "~/Downloads",
+        "~/.Trash",
+        "/private/var/folders",
+        "~/Library/Containers/com.docker.docker/Data",
+        "~/.docker",
+    ]
+else:  # Linux
+    CACHE_DIRS = [
+        "~/.cache",
+        "~/.local/share/Trash",
+        "/tmp",
+        "/var/tmp",
+        "~/.config/Code/Cache",
+        "~/.config/Code/CachedData",
+        "~/.mozilla/firefox",
+        "~/.cache/google-chrome",
+        "~/.npm",
+        "~/Downloads",
+        "/var/cache",
+        "~/.docker",
+        "/var/lib/docker",
+    ]
+
+# Extensiones de archivos grandes comunes
+LARGE_FILE_EXTENSIONS = {
+    '.dmg', '.iso', '.pkg', '.zip', '.rar', '.7z',
+    '.mov', '.mp4', '.avi', '.mkv', '.mpg',
+    '.psd', '.ai', '.sketch',
+    '.vmdk', '.vdi', '.qcow2'
+}
+
+# Archivos/carpetas a ignorar
+IGNORE_PATTERNS = {
+    '.DS_Store', '.localized', 'node_modules', '__pycache__',
+    '.git/objects', 'venv', 'env', '.virtualenv', 'Docker.raw'
+}
+
+# Volúmenes APFS a excluir en macOS para evitar doble conteo por firmlinks
+MACOS_APFS_SKIP_DIRS = {
+    '/System/Volumes/Data',
+    '/System/Volumes/VM',
+    '/System/Volumes/Preboot',
+    '/System/Volumes/Update',
+    '/System/Volumes/xarts',
+    '/System/Volumes/iSCPreboot',
+    '/System/Volumes/Hardware',
+}
+
+# Prefijos de rutas del sistema que nunca deben tener comandos de borrado
+# Estas se comparan con startswith() para evitar falsos positivos por substring
+PROTECTED_PATH_PREFIXES = [
+    # Volúmenes del sistema macOS
+    '/System/Volumes/',
+    '/private/var/vm/',
+    '/var/vm/',
+    # Bibliotecas y frameworks del sistema
+    '/System/Library/',
+    '/usr/lib/',
+    '/usr/bin/',
+    '/usr/sbin/',
+    '/Library/Updates/',
+    '/private/var/folders/',
+]
+
+# Prefijos que protegen internos de apps (Contents/ dentro de un .app o .AppBundle)
+# pero NO el .app en sí (el usuario puede borrar una app entera)
+PROTECTED_APP_MARKERS = ['.app/', '.AppBundle/']
+
+# Nombres de archivo del sistema (match exacto contra el nombre, no la ruta)
+PROTECTED_FILENAMES = {'sleepimage', 'swapfile'}
+
+# Rutas raíz del sistema (match exacto de los primeros componentes)
+PROTECTED_ROOT_DIRS = {'/bin', '/sbin'}

--- a/analyzer/measurement.py
+++ b/analyzer/measurement.py
@@ -1,0 +1,37 @@
+"""Shared directory-size measurement.
+
+Task 5 reconciliation: the CLI used to shell out to `du -sk` while the core
+engine walked the tree with `rglob` and summed `st_blocks * 512`. The two
+could give different answers for the same directory (see the git history of
+disk_analyzer.py's old get_directory_size for the `du`-based version). We
+keep the core's approach -- it's consistent with how the rest of the engine
+measures disk usage (scan_directory also uses st_blocks) and it doesn't
+depend on a subprocess -- and both the CLI and the core now delegate here.
+
+Known consequence: this walk sums every directory entry's on-disk blocks,
+so a file with multiple hard links is counted once per link, whereas `du`
+dedupes by inode and counts it once. Sparse files and symlinks are also
+handled differently than `du` might. This is an accepted trade-off: the
+goal was ONE answer shared across the engine, not bit-for-bit parity with
+`du`.
+
+Standard library only -- analyzer/ must not depend on third-party packages.
+"""
+from pathlib import Path
+
+
+def get_directory_size(directory: Path) -> int:
+    """Calcula el tamaño de un directorio sumando el uso real en disco
+    (bloques asignados), no el tamaño lógico de los archivos."""
+    total_size = 0
+    try:
+        for entry in directory.rglob('*'):
+            if entry.is_file(follow_symlinks=False):
+                try:
+                    stat = entry.stat(follow_symlinks=False)
+                    total_size += stat.st_blocks * 512 if hasattr(stat, 'st_blocks') else stat.st_size
+                except OSError:
+                    pass
+    except OSError:
+        pass
+    return total_size

--- a/analyzer/protection.py
+++ b/analyzer/protection.py
@@ -1,0 +1,22 @@
+"""Protected-path detection, shared by the CLI, core engine and web backend."""
+
+from pathlib import Path
+
+from analyzer.constants import (
+    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
+    PROTECTED_ROOT_DIRS,
+)
+
+
+def is_protected_path(file_path: str) -> bool:
+    """Determina si un archivo es del sistema y no debe borrarse"""
+    if any(file_path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
+        return True
+    parts = Path(file_path).parts
+    if len(parts) >= 2 and '/' + parts[1] in PROTECTED_ROOT_DIRS:
+        return True
+    if '/Contents/' in file_path and any(m in file_path for m in PROTECTED_APP_MARKERS):
+        return True
+    if Path(file_path).name in PROTECTED_FILENAMES:
+        return True
+    return False

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -24,6 +24,7 @@ from analyzer.constants import (
 )
 from analyzer import protection
 from analyzer import cache_types
+from analyzer import measurement
 
 class DiskAnalyzer:
     def __init__(self, start_path: str, min_size_mb: float = 10):
@@ -430,19 +431,10 @@ class DiskAnalyzer:
         return 0
     
     def get_directory_size(self, path: Path) -> int:
-        """Obtiene el tamaño de un directorio usando du"""
-        try:
-            # du -sk es POSIX (macOS + Linux), du -sb es solo GNU/Linux
-            result = subprocess.run(
-                ['du', '-sk', str(path)],
-                capture_output=True,
-                text=True
-            )
-            if result.returncode == 0 and result.stdout.strip():
-                return int(result.stdout.split()[0]) * 1024
-        except:
-            pass
-        return 0
+        """Calcula el tamaño de un directorio (delega en analyzer.measurement,
+        la misma implementación que usa el core; antes usaba `du -sk`, ver
+        Task 5 de la Fase 3 para el motivo de la reconciliación)."""
+        return measurement.get_directory_size(path)
     
     def get_disk_usage(self, path: Optional[str] = None) -> Dict:
         """Obtiene el uso total del disco de forma multiplataforma"""

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -18,119 +18,12 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Dict, List, Tuple, Optional
 
-# Configuración de tamaños
-KB = 1024
-MB = KB * 1024
-GB = MB * 1024
-
-# Detección del sistema operativo
-SYSTEM = platform.system()
-IS_WINDOWS = SYSTEM == 'Windows'
-IS_MACOS = SYSTEM == 'Darwin'
-IS_LINUX = SYSTEM == 'Linux'
-
-# Directorios típicos con archivos temporales o cache por sistema
-if IS_WINDOWS:
-    CACHE_DIRS = [
-        "~/AppData/Local/Temp",
-        "~/AppData/Local/Microsoft/Windows/INetCache",
-        "~/AppData/Local/Microsoft/Windows/Explorer",
-        "~/AppData/Roaming/Code/Cache",
-        "~/AppData/Roaming/Code/CachedData",
-        "~/AppData/Local/Google/Chrome/User Data/Default/Cache",
-        "~/AppData/Local/Mozilla/Firefox/Profiles",
-        "~/.npm",
-        "~/.cache",
-        "~/Downloads",
-        "$RECYCLE.BIN",
-        "C:/Windows/Temp",
-        "~/AppData/Local/Docker",
-        "~/.docker",
-    ]
-elif IS_MACOS:
-    CACHE_DIRS = [
-        "~/Library/Caches",
-        "~/Library/Logs",
-        "~/Library/Application Support/Code/Cache",
-        "~/Library/Application Support/Code/CachedData",
-        "~/Library/Developer/Xcode/DerivedData",
-        "~/Library/Developer/Xcode/Archives",
-        "~/Library/Developer/CoreSimulator/Devices",
-        "~/.npm",
-        "~/.cache",
-        "~/Downloads",
-        "~/.Trash",
-        "/private/var/folders",
-        "~/Library/Containers/com.docker.docker/Data",
-        "~/.docker",
-    ]
-else:  # Linux
-    CACHE_DIRS = [
-        "~/.cache",
-        "~/.local/share/Trash",
-        "/tmp",
-        "/var/tmp",
-        "~/.config/Code/Cache",
-        "~/.config/Code/CachedData",
-        "~/.mozilla/firefox",
-        "~/.cache/google-chrome",
-        "~/.npm",
-        "~/Downloads",
-        "/var/cache",
-        "~/.docker",
-        "/var/lib/docker",
-    ]
-
-# Extensiones de archivos grandes comunes
-LARGE_FILE_EXTENSIONS = {
-    '.dmg', '.iso', '.pkg', '.zip', '.rar', '.7z',
-    '.mov', '.mp4', '.avi', '.mkv', '.mpg',
-    '.psd', '.ai', '.sketch',
-    '.vmdk', '.vdi', '.qcow2'
-}
-
-# Archivos/carpetas a ignorar
-IGNORE_PATTERNS = {
-    '.DS_Store', '.localized', 'node_modules', '__pycache__',
-    '.git/objects', 'venv', 'env', '.virtualenv', 'Docker.raw'
-}
-
-# Volúmenes APFS a excluir en macOS para evitar doble conteo por firmlinks
-MACOS_APFS_SKIP_DIRS = {
-    '/System/Volumes/Data',
-    '/System/Volumes/VM',
-    '/System/Volumes/Preboot',
-    '/System/Volumes/Update',
-    '/System/Volumes/xarts',
-    '/System/Volumes/iSCPreboot',
-    '/System/Volumes/Hardware',
-}
-
-# Prefijos de rutas del sistema que nunca deben tener comandos de borrado
-# Estas se comparan con startswith() para evitar falsos positivos por substring
-PROTECTED_PATH_PREFIXES = [
-    # Volúmenes del sistema macOS
-    '/System/Volumes/',
-    '/private/var/vm/',
-    '/var/vm/',
-    # Bibliotecas y frameworks del sistema
-    '/System/Library/',
-    '/usr/lib/',
-    '/usr/bin/',
-    '/usr/sbin/',
-    '/Library/Updates/',
-    '/private/var/folders/',
-]
-
-# Prefijos que protegen internos de apps (Contents/ dentro de un .app o .AppBundle)
-# pero NO el .app en sí (el usuario puede borrar una app entera)
-PROTECTED_APP_MARKERS = ['.app/', '.AppBundle/']
-
-# Nombres de archivo del sistema (match exacto contra el nombre, no la ruta)
-PROTECTED_FILENAMES = {'sleepimage', 'swapfile'}
-
-# Rutas raíz del sistema (match exacto de los primeros componentes)
-PROTECTED_ROOT_DIRS = {'/bin', '/sbin'}
+from analyzer.constants import (
+    KB, MB, GB, SYSTEM, IS_WINDOWS, IS_MACOS, IS_LINUX,
+    CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
+    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
+    PROTECTED_ROOT_DIRS,
+)
 
 class DiskAnalyzer:
     def __init__(self, start_path: str, min_size_mb: float = 10):

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -21,9 +21,8 @@ from typing import Dict, List, Tuple, Optional
 from analyzer.constants import (
     KB, MB, GB, SYSTEM, IS_WINDOWS, IS_MACOS, IS_LINUX,
     CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
-    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
-    PROTECTED_ROOT_DIRS,
 )
+from analyzer import protection
 
 class DiskAnalyzer:
     def __init__(self, start_path: str, min_size_mb: float = 10):
@@ -598,21 +597,8 @@ class DiskAnalyzer:
         }
     
     def is_protected_path(self, file_path: str) -> bool:
-        """Determina si un archivo es del sistema y no debe borrarse"""
-        # Prefijos de rutas del sistema
-        if any(file_path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
-            return True
-        # Rutas raíz del sistema (/bin, /sbin - no /Users/robin/)
-        parts = Path(file_path).parts
-        if len(parts) >= 2 and '/' + parts[1] in PROTECTED_ROOT_DIRS:
-            return True
-        # Internos de aplicaciones (.app/Contents/... o .AppBundle/Contents/...)
-        if '/Contents/' in file_path and any(m in file_path for m in PROTECTED_APP_MARKERS):
-            return True
-        # Nombres de archivo del sistema (match exacto)
-        if Path(file_path).name in PROTECTED_FILENAMES:
-            return True
-        return False
+        """Delegates to the shared implementation (kept for callers)."""
+        return protection.is_protected_path(file_path)
 
     def _categorize_path(self, dir_path: str) -> str:
         """Asigna una categoría a un directorio basado en su ruta"""

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -23,6 +23,7 @@ from analyzer.constants import (
     CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
 )
 from analyzer import protection
+from analyzer import cache_types
 
 class DiskAnalyzer:
     def __init__(self, start_path: str, min_size_mb: float = 10):
@@ -277,24 +278,10 @@ class DiskAnalyzer:
                     pass
     
     def classify_cache(self, path: Path) -> str:
-        """Clasifica el tipo de cache"""
-        path_str = str(path).lower()
-        if 'docker' in path_str:
-            return 'Docker'
-        elif 'xcode' in path_str:
-            return 'Xcode Development'
-        elif 'code' in path_str or 'vscode' in path_str:
-            return 'VS Code'
-        elif 'npm' in path_str or 'node' in path_str:
-            return 'Node.js/npm'
-        elif 'downloads' in path_str:
-            return 'Downloads'
-        elif 'trash' in path_str:
-            return 'Papelera'
-        elif 'logs' in path_str:
-            return 'Logs del Sistema'
-        else:
-            return 'Cache General'
+        """Clasifica el tipo de cache. Delega en el clasificador compartido
+        (analyzer.cache_types) para que CLI, web y GUI usen las mismas
+        etiquetas."""
+        return cache_types.classify(path)
     
     def analyze_docker(self):
         """Analiza el uso de espacio de Docker"""
@@ -900,13 +887,13 @@ class DiskAnalyzer:
 
         # ── TIER 1: Seguro (auto-limpiable, sin revisión) ──
         # Logs del sistema
-        log_locs = [l for l in self.cache_locations if l['type'] == 'Logs del Sistema']
+        log_locs = [l for l in self.cache_locations if l['type'] == cache_types.LOGS]
         if log_locs:
             size = sum(l['size'] for l in log_locs)
             if size > 10 * MB:
                 recommendations.append({
                     'tier': 1, 'priority': 'Seguro',
-                    'type': 'Logs del Sistema',
+                    'type': cache_types.LOGS,
                     'description': f'{self.format_size(size)} en logs del sistema',
                     'space': size,
                     'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)
@@ -925,7 +912,7 @@ class DiskAnalyzer:
             })
 
         # VS Code caches
-        vscode_locs = [l for l in self.cache_locations if l['type'] == 'VS Code']
+        vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
         if vscode_locs:
             size = sum(l['size'] for l in vscode_locs)
             if size > 10 * MB:
@@ -938,7 +925,7 @@ class DiskAnalyzer:
                 })
 
         # npm cache
-        npm_locs = [l for l in self.cache_locations if l['type'] == 'Node.js/npm']
+        npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs:
             size = sum(l['size'] for l in npm_locs)
             if size > 50 * MB:
@@ -990,7 +977,7 @@ class DiskAnalyzer:
         # ── TIER 3: Agresivo (puede requerir re-descargas) ──
         # ~/.cache (huggingface, pip, etc.)
         cache_general = [l for l in self.cache_locations
-                         if l['type'] == 'Cache General' and '/.cache' in l['path']]
+                         if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
         if cache_general:
             size = sum(l['size'] for l in cache_general)
             if size > 100 * MB:
@@ -1003,7 +990,7 @@ class DiskAnalyzer:
                 })
 
         # Xcode DerivedData
-        xcode_locs = [l for l in self.cache_locations if l['type'] == 'Xcode Development']
+        xcode_locs = [l for l in self.cache_locations if l['type'] == cache_types.XCODE]
         if xcode_locs:
             size = sum(l['size'] for l in xcode_locs)
             if size > 100 * MB:
@@ -4515,10 +4502,7 @@ class DiskAnalyzer:
             path = Path(cache_loc['path'])
             
             # Solo limpiar caches seguros — NUNCA Downloads ni Cache General
-            safe_to_clean = cache_loc['type'] in {
-                'Logs del Sistema', 'VS Code', 'Node.js/npm',
-                'Xcode Development', 'Python Cache'
-            }
+            safe_to_clean = cache_loc['type'] in cache_types.SAFE_TO_CLEAN
 
             if safe_to_clean and path.exists():
                 if dry_run:

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -16,103 +16,12 @@ from datetime import datetime
 from collections import defaultdict
 from typing import Dict, List, Tuple, Optional, Callable
 
-# Configuración de tamaños
-KB = 1024
-MB = KB * 1024
-GB = MB * 1024
-
-# Detección del sistema operativo
-SYSTEM = platform.system()
-IS_WINDOWS = SYSTEM == 'Windows'
-IS_MACOS = SYSTEM == 'Darwin'
-IS_LINUX = SYSTEM == 'Linux'
-
-# Directorios típicos con archivos temporales o cache por sistema
-if IS_WINDOWS:
-    CACHE_DIRS = [
-        "~/AppData/Local/Temp",
-        "~/AppData/Local/Microsoft/Windows/INetCache",
-        "~/AppData/Local/Microsoft/Windows/Explorer",
-        "~/AppData/Roaming/Code/Cache",
-        "~/AppData/Roaming/Code/CachedData",
-        "~/AppData/Local/Google/Chrome/User Data/Default/Cache",
-        "~/AppData/Local/Mozilla/Firefox/Profiles",
-        "~/.npm",
-        "~/.cache",
-        "~/Downloads",
-        "$RECYCLE.BIN",
-        "C:/Windows/Temp",
-        "~/AppData/Local/Docker",
-        "~/.docker",
-    ]
-elif IS_MACOS:
-    CACHE_DIRS = [
-        "~/Library/Caches",
-        "~/Library/Logs",
-        "~/Library/Application Support/Code/Cache",
-        "~/Library/Application Support/Code/CachedData",
-        "~/Library/Developer/Xcode/DerivedData",
-        "~/Library/Developer/Xcode/Archives",
-        "~/Library/Developer/CoreSimulator/Devices",
-        "~/.npm",
-        "~/.cache",
-        "~/Downloads",
-        "~/.Trash",
-        "/private/var/folders",
-        "~/Library/Containers/com.docker.docker/Data",
-        "~/.docker",
-    ]
-else:  # Linux
-    CACHE_DIRS = [
-        "~/.cache",
-        "~/.local/share/Trash",
-        "/tmp",
-        "/var/tmp",
-        "~/.config/Code/Cache",
-        "~/.config/Code/CachedData",
-        "~/.mozilla/firefox",
-        "~/.cache/google-chrome",
-        "~/.npm",
-        "~/Downloads",
-        "/var/cache",
-        "~/.docker",
-        "/var/lib/docker",
-    ]
-
-# Extensiones de archivos grandes comunes
-LARGE_FILE_EXTENSIONS = {
-    '.dmg', '.iso', '.pkg', '.zip', '.rar', '.7z',
-    '.mov', '.mp4', '.avi', '.mkv', '.mpg',
-    '.psd', '.ai', '.sketch',
-    '.vmdk', '.vdi', '.qcow2'
-}
-
-# Archivos/carpetas a ignorar
-IGNORE_PATTERNS = {
-    '.DS_Store', '.localized', 'node_modules', '__pycache__',
-    '.git/objects', 'venv', 'env', '.virtualenv', 'Docker.raw'
-}
-
-# Volúmenes APFS a excluir en macOS para evitar doble conteo por firmlinks
-MACOS_APFS_SKIP_DIRS = {
-    '/System/Volumes/Data',
-    '/System/Volumes/VM',
-    '/System/Volumes/Preboot',
-    '/System/Volumes/Update',
-    '/System/Volumes/xarts',
-    '/System/Volumes/iSCPreboot',
-    '/System/Volumes/Hardware',
-}
-
-# Protección de archivos del sistema
-PROTECTED_PATH_PREFIXES = [
-    '/System/Volumes/', '/private/var/vm/', '/var/vm/',
-    '/System/Library/', '/usr/lib/', '/usr/bin/', '/usr/sbin/',
-    '/Library/Updates/', '/private/var/folders/',
-]
-PROTECTED_APP_MARKERS = ['.app/', '.AppBundle/']
-PROTECTED_FILENAMES = {'sleepimage', 'swapfile'}
-PROTECTED_ROOT_DIRS = {'/bin', '/sbin'}
+from analyzer.constants import (
+    KB, MB, GB, SYSTEM, IS_WINDOWS, IS_MACOS, IS_LINUX,
+    CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
+    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
+    PROTECTED_ROOT_DIRS,
+)
 
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -22,6 +22,7 @@ from analyzer.constants import (
 )
 from analyzer import protection
 from analyzer import cache_types
+from analyzer import measurement
 
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""
@@ -269,7 +270,7 @@ class DiskAnalyzerCore:
                         phase="cache_scan"
                     )
                     size = self.get_directory_size(path)
-                    if size > 0:
+                    if size > MB:  # Solo reportar si es mayor a 1MB (igual que el CLI)
                         cache_type = self.categorize_cache(path)
                         self.cache_locations.append({
                             'path': str(path),
@@ -286,19 +287,9 @@ class DiskAnalyzerCore:
                     pass
     
     def get_directory_size(self, directory: Path) -> int:
-        """Calcula el tamaño de un directorio"""
-        total_size = 0
-        try:
-            for entry in directory.rglob('*'):
-                if entry.is_file(follow_symlinks=False):
-                    try:
-                        stat = entry.stat(follow_symlinks=False)
-                        total_size += stat.st_blocks * 512 if hasattr(stat, 'st_blocks') else stat.st_size
-                    except:
-                        pass
-        except:
-            pass
-        return total_size
+        """Calcula el tamaño de un directorio (delega en analyzer.measurement,
+        la misma implementación que usa el CLI)."""
+        return measurement.get_directory_size(directory)
     
     def categorize_cache(self, path: Path) -> str:
         """Categoriza el tipo de cache. Delega en el clasificador compartido

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -21,6 +21,7 @@ from analyzer.constants import (
     CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
 )
 from analyzer import protection
+from analyzer import cache_types
 
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""
@@ -300,33 +301,10 @@ class DiskAnalyzerCore:
         return total_size
     
     def categorize_cache(self, path: Path) -> str:
-        """Categoriza el tipo de cache"""
-        path_str = str(path).lower()
-        
-        if 'code' in path_str or 'vscode' in path_str:
-            return 'VS Code Cache'
-        elif 'chrome' in path_str:
-            return 'Chrome Cache'
-        elif 'firefox' in path_str or 'mozilla' in path_str:
-            return 'Firefox Cache'
-        elif 'npm' in path_str or 'node' in path_str:
-            return 'NPM Cache'
-        elif 'pip' in path_str or 'python' in path_str:
-            return 'Python Cache'
-        elif 'xcode' in path_str:
-            return 'Xcode Cache'
-        elif 'docker' in path_str:
-            return 'Docker'
-        elif 'trash' in path_str or 'recycle' in path_str:
-            return 'Papelera'
-        elif 'temp' in path_str or 'tmp' in path_str:
-            return 'Archivos Temporales'
-        elif 'log' in path_str:
-            return 'Logs del Sistema'
-        elif 'download' in path_str:
-            return 'Downloads'
-        else:
-            return 'Cache General'
+        """Categoriza el tipo de cache. Delega en el clasificador compartido
+        (analyzer.cache_types) para que CLI, web y GUI usen las mismas
+        etiquetas."""
+        return cache_types.classify(path)
     
     def get_disk_usage(self, path: Optional[str] = None) -> Dict:
         """Obtiene el uso total del disco de forma multiplataforma"""
@@ -589,9 +567,9 @@ class DiskAnalyzerCore:
         recommendations = []
 
         # TIER 1: Seguro
-        log_locs = [l for l in self.cache_locations if l['type'] == 'Logs del Sistema']
+        log_locs = [l for l in self.cache_locations if l['type'] == cache_types.LOGS]
         if log_locs and sum(l['size'] for l in log_locs) > 10 * MB:
-            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Logs del Sistema',
+            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
                 'description': f'{self.format_size(sum(l["size"] for l in log_locs))} en logs',
                 'space': sum(l['size'] for l in log_locs),
                 'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)})
@@ -603,14 +581,14 @@ class DiskAnalyzerCore:
                 'description': f'{len(brew_files)} descargas ({self.format_size(size)})',
                 'space': size, 'command': 'brew cleanup --prune=all'})
 
-        vscode_locs = [l for l in self.cache_locations if l['type'] == 'VS Code Cache']
+        vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
         if vscode_locs and sum(l['size'] for l in vscode_locs) > 10 * MB:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
                 'description': f'{self.format_size(sum(l["size"] for l in vscode_locs))} en cache',
                 'space': sum(l['size'] for l in vscode_locs),
                 'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in vscode_locs)})
 
-        npm_locs = [l for l in self.cache_locations if l['type'] == 'NPM Cache']
+        npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
                 'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache',
@@ -638,7 +616,7 @@ class DiskAnalyzerCore:
                 'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f'})
 
         # TIER 3: Agresivo
-        cache_general = [l for l in self.cache_locations if l['type'] == 'Cache General' and '/.cache' in l['path']]
+        cache_general = [l for l in self.cache_locations if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
         if cache_general and sum(l['size'] for l in cache_general) > 100 * MB:
             recommendations.append({'tier': 3, 'priority': 'Agresivo', 'type': 'Cache General (~/.cache)',
                 'description': f'{self.format_size(sum(l["size"] for l in cache_general))} (modelos ML, pip, etc.)',

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -19,9 +19,8 @@ from typing import Dict, List, Tuple, Optional, Callable
 from analyzer.constants import (
     KB, MB, GB, SYSTEM, IS_WINDOWS, IS_MACOS, IS_LINUX,
     CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
-    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
-    PROTECTED_ROOT_DIRS,
 )
+from analyzer import protection
 
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""
@@ -98,17 +97,8 @@ class DiskAnalyzerCore:
         return any(pattern in path_str for pattern in IGNORE_PATTERNS)
 
     def is_protected_path(self, file_path: str) -> bool:
-        """Determina si un archivo es del sistema y no debe borrarse"""
-        if any(file_path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
-            return True
-        parts = Path(file_path).parts
-        if len(parts) >= 2 and '/' + parts[1] in PROTECTED_ROOT_DIRS:
-            return True
-        if '/Contents/' in file_path and any(m in file_path for m in PROTECTED_APP_MARKERS):
-            return True
-        if Path(file_path).name in PROTECTED_FILENAMES:
-            return True
-        return False
+        """Delegates to the shared implementation (kept for callers)."""
+        return protection.is_protected_path(file_path)
     
     def get_home_dir(self) -> Path:
         """Obtiene el directorio home según el sistema"""

--- a/disk_analyzer_web.py
+++ b/disk_analyzer_web.py
@@ -28,6 +28,7 @@ import uvicorn
 
 # Import our core analyzer
 from disk_analyzer_core import DiskAnalyzerCore, MB, GB, IS_MACOS, IS_WINDOWS
+from analyzer.protection import is_protected_path
 from pty_manager import PTYManager
 from agents_manager import AgentsManager
 from persona_detector import detect_personas, generate_persona_recommendations
@@ -886,14 +887,13 @@ def _perform_cleanup_deletes(actions: list) -> tuple:
     unlink()/shutil.rmtree() on large directories can block for a while, so
     this is run via asyncio.to_thread instead of inline in the async handler.
     """
-    checker = DiskAnalyzerCore(str(Path.home()))
     deleted: list[dict] = []
     errors: list[dict] = []
     freed_size = 0
 
     for action in actions:
         target = Path(action["path"]).resolve()
-        if checker.is_protected_path(str(target)):
+        if is_protected_path(str(target)):
             errors.append({"path": str(target), "error": "Ruta protegida del sistema"})
             continue
         try:
@@ -1039,10 +1039,8 @@ async def delete_file(request: DeleteFileRequest):
             raise HTTPException(status_code=400, detail="Path is not a file")
         
         # 4. Prevent deletion of system files using shared protection logic
-        from disk_analyzer_core import DiskAnalyzerCore
-        checker = DiskAnalyzerCore.__new__(DiskAnalyzerCore)
         path_str = str(resolved_path)
-        if checker.is_protected_path(path_str):
+        if is_protected_path(path_str):
             raise HTTPException(
                 status_code=403,
                 detail="Cannot delete system files"

--- a/docs/superpowers/plans/2026-07-15-registro-ejecucion.md
+++ b/docs/superpowers/plans/2026-07-15-registro-ejecucion.md
@@ -187,7 +187,78 @@ contra descriptores que sí sean heredables, presentes o futuros, sin depender d
 que cada punto del código recuerde marcarlos. Vale registrarlo así para que
 nadie sobrevalore la severidad al leer el historial.
 
-## Fases 0 y 3 a 5
+## Fase 3 — Motor compartido
+
+**Estado:** completa y verificada en la rama `feat/fase3-motor-compartido`,
+creada desde `feat/fase2-seguridad`. Sin mergear. Tests: 79 → 137.
+
+| Task | Qué hace | Estado |
+|---|---|---|
+| 1 | Red de tests de caracterización del motor (antes no había ninguno) | ✅ `cbf7bc5`, `5455a18` |
+| 2 | Constantes compartidas en `analyzer/constants.py` | ✅ `36b15fe` |
+| 3 | `is_protected_path` en `analyzer/protection.py` | ✅ `acd3395` |
+| 4 | Una sola clasificación de cachés con etiquetas como constantes | ✅ `102c678`, `871eb6c` |
+| 5 | Una sola forma de medir directorios y un solo umbral de cachés | ✅ `0374706` |
+| 6 | Verificación integral | ✅ |
+
+Resultado: `disk_analyzer.py` 4.882 → 4.737 líneas, `disk_analyzer_core.py` 762
+→ 630, más 281 líneas de paquete `analyzer/` compartido. La cifra neta importa
+menos que el hecho de que constantes, protección de rutas, clasificación de
+cachés y medición de directorios ahora existen **una sola vez**.
+
+### Lo que encontró la red de caracterización
+
+Escribir los tests antes de mover nada era el paso obligatorio del plan, y se
+pagó solo: destapó un bug real en el motor que usan la web y la GUI.
+`categorize_cache` evaluaba `'code' in path_str` antes que `'xcode'`, y como
+"code" es substring de "xcode", toda ruta de Xcode se clasificaba como
+`'VS Code Cache'` y la rama de Xcode era código muerto. Los usuarios de web y
+GUI veían sus cachés de Xcode mal etiquetadas y la recomendación específica de
+Xcode nunca disparaba. El CLI lo hacía bien. El Task 4 lo arregló al unificar.
+
+También durante la revisión: dos tests de caracterización resultaron ser vacuos
+(no fallaban ante la mutación que decían detectar) y se reforzaron; y el Task 3
+destapó que `/api/files/delete` usaba `DiskAnalyzerCore.__new__(DiskAnalyzerCore)`
+para saltarse el `__init__` entero, un rodeo peor que el que el plan había
+detectado.
+
+### Decisiones de diseño de la fase
+
+| Decisión | Alternativas | Motivo |
+|---|---|---|
+| Conservar el conjunto de 12 etiquetas del core | Las 8 del CLI | Es el más granular y el que ya ven la web y la GUI; las recomendaciones del core se le alinearon en la Fase 1 |
+| Medir directorios con `rglob` + `st_blocks` | `du -sk` por subproceso, como hacía el CLI | Coherente con cómo mide el resto del motor y sin depender de un subproceso. Consecuencia medida: sobre este repo da +3,29 % frente a `du`, porque `du` cuenta los enlaces duros una vez y el recorrido los cuenta por cada entrada (npm crea enlaces duros en `node_modules`) |
+| Umbral de cachés en `> MB` | El `> 0` del core | Una caché de 3 KB no es accionable y solo ensucia la lista |
+| **No** hacer borrables las cachés de Python | Incluir `PYTHON` en `SAFE_TO_CLEAN` | Ver abajo |
+
+### La decisión sobre las cachés de Python
+
+El safelist viejo del CLI contenía literalmente `'Python Cache'`, pero su
+clasificador nunca producía esa etiqueta: era una entrada muerta, y las cachés
+de Python siempre caían en `'Cache General'` y no se limpiaban nunca. Al
+unificar, el clasificador compartido sí produce esa etiqueta, así que incluirla
+en el safelist las habría hecho borrables por primera vez.
+
+Se decidió **excluirlas**, y conviene registrar por qué, porque el primer
+razonamiento fue equivocado. La justificación inicial para dejarlo pasar era que
+`clean_cache` manda a la Papelera en macOS y pide confirmación. Al verificar el
+código resultó falso a medias: la rama de Papelera solo aplica a archivos
+sueltos; para **directorios** —que es exactamente lo que son las cachés de
+Python— hace `item.unlink()`, borrado permanente. Y la confirmación es una sola
+para todo el lote, no por categoría.
+
+Así que se restauró la paridad real de comportamiento (lo que el CLI *hacía*, no
+lo que su texto muerto decía) y queda como decisión explícita del dueño del
+proyecto, no como efecto colateral de un refactor.
+
+### Hallazgo pendiente que vale la pena no perder
+
+`clean_cache` borra directorios con `unlink()` permanente para **todas** las
+categorías del safelist, no solo las de Python, y eso contradice su propio
+comentario "Mover a Trash en macOS". Afecta a logs, VS Code, npm y Xcode.
+Candidato claro para una fase posterior.
+
+## Fases 0, 4 y 5
 
 Sin ejecutar. El alcance, la secuencia recomendada y los criterios de
 aceptación de cada una están en el

--- a/docs/superpowers/plans/2026-07-30-mejoras-fase3-motor-compartido.md
+++ b/docs/superpowers/plans/2026-07-30-mejoras-fase3-motor-compartido.md
@@ -1,0 +1,744 @@
+# Plan de Mejoras — Fase 3: Motor compartido
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminar la duplicación entre `disk_analyzer.py` (CLI) y `disk_analyzer_core.py` (motor de web y GUI), para que un bug se arregle en un solo lugar.
+
+**Architecture:** Extracción incremental a un paquete `analyzer/`, en orden de riesgo creciente: primero una red de tests de caracterización, luego las constantes (idénticas byte a byte, movimiento mecánico), luego la protección de rutas, luego la clasificación de cachés (la única con implicaciones de comportamiento reales), y por último el escaneo. `disk_analyzer.py` conserva su CLI y su generador de reportes HTML; deja de tener su propia copia del motor.
+
+**Tech Stack:** Python 3.13, pytest. Sin dependencias nuevas: el CLI debe seguir funcionando solo con la biblioteca estándar.
+
+## Global Constraints
+
+- Tests: `venv-web/bin/python -m pytest tests/ -v` desde la raíz. Baseline: **79 passed**. Verde antes de cada commit.
+- **El CLI no puede adquirir dependencias externas.** `analyzer/` usa solo la biblioteca estándar. Verificación: `python3 -c "import analyzer"` con el Python del sistema, sin venv.
+- Mensajes de cara al usuario en español; comentarios de código en inglés.
+- **Ningún cambio de comportamiento salvo donde este plan lo diga explícitamente.** Los tests de caracterización del Task 1 son el contrato: si uno se rompe en un task posterior, es un bug del refactor, no un test que actualizar — salvo que el task diga lo contrario y explique por qué.
+- Cada task es un commit. No mezclar movimiento mecánico con cambio de comportamiento en el mismo commit.
+- Al terminar cada task, verificar las tres interfaces a mano, no solo la suite:
+  `venv-web/bin/python disk_analyzer.py ./test --min-size 1` (o cualquier ruta pequeña),
+  `venv-web/bin/python -c "import disk_analyzer_web"`, y
+  `venv-web/bin/python -c "import disk_analyzer_gui"` (puede fallar por falta de customtkinter: eso es aceptable, lo que importa es que no falle por el refactor).
+
+## Contexto: qué está duplicado
+
+Inventario verificado. La duplicación es **bidireccional** entre `DiskAnalyzer`
+(4.882 líneas) y `DiskAnalyzerCore` (762). La GUI no tiene motor propio: importa
+el core. `disk_analyzer_web.py` importa el core, y toca el monolito en un solo
+punto (`generate_html_report`, para el export HTML).
+
+- **Constantes idénticas en valor** (`KB/MB/GB`, `CACHE_DIRS` en sus tres
+  variantes de plataforma, `LARGE_FILE_EXTENSIONS`, `IGNORE_PATTERNS`,
+  `MACOS_APFS_SKIP_DIRS`, `PROTECTED_*`): copia literal, sin divergencias.
+- **Métodos idénticos**: `format_size`, `get_file_age`, `is_cache_or_temp`,
+  `should_ignore`, `is_protected_path`, `get_home_dir`, `get_temp_dirs`,
+  `get_disk_usage`.
+- **Divergencias reales que hay que reconciliar**:
+  - `get_directory_size`: el CLI usa `du -sk` por subproceso
+    (`disk_analyzer.py:553`), el core recorre con `rglob` y `st_blocks`
+    (`disk_analyzer_core.py:388`). Pueden dar totales distintos para el mismo
+    directorio.
+  - `find_cache_locations`: el CLI solo reporta si `size > MB`
+    (`disk_analyzer.py:378`), el core si `size > 0`
+    (`disk_analyzer_core.py:372`).
+  - Clasificación de cachés: el CLI tiene `classify_cache` con 8 etiquetas
+    (`'Docker'`, `'Xcode Development'`, `'VS Code'`, `'Node.js/npm'`,
+    `'Downloads'`, `'Papelera'`, `'Logs del Sistema'`, `'Cache General'`); el
+    core tiene `categorize_cache` con 12 (`'VS Code Cache'`, `'Chrome Cache'`,
+    `'Firefox Cache'`, `'NPM Cache'`, `'Python Cache'`, `'Xcode Cache'`,
+    `'Docker'`, `'Papelera'`, `'Archivos Temporales'`, `'Logs del Sistema'`,
+    `'Downloads'`, `'Cache General'`), con distinta precedencia.
+  - `get_all_drives`: devuelve `List[str]` en el CLI, `List[Dict]` en el core.
+  - `scan_directory`: misma lógica de conteo; difiere el andamiaje (progreso por
+    TTY y estimación de ETA en el CLI; callback de progreso, cancelación y
+    `max_depth` en el core).
+
+**Trampa conocida:** las etiquetas de caché no son cosméticas. Las consume el
+safelist de `clean_cache` (`disk_analyzer.py`), los filtros de
+`generate_recommendations` en ambos módulos, y el emparejamiento por categoría
+de `/api/cleanup/preview`. Cambiar una etiqueta sin actualizar a sus tres
+consumidores rompe funcionalidad en silencio: ya pasó una vez (Fase 1, Task 3).
+
+---
+
+### Task 1: Red de tests de caracterización del motor
+
+Antes de mover una sola línea hay que fijar el comportamiento actual. Hoy el
+motor no tiene ningún test: la suite cubre terminal, auth, agents y cleanup, pero
+nada de escaneo, categorización ni recomendaciones. Sin esta red, el refactor es
+a ciegas.
+
+Estos tests describen **lo que el código hace hoy**, no lo que debería hacer. Si
+alguno documenta algo que parece un bug, se anota en el reporte y se deja pasar:
+arreglarlo es otra tarea, no esta.
+
+**Files:**
+- Create: `tests/test_engine_characterization.py`
+- Test: el archivo es el entregable
+
+**Interfaces:**
+- Consumes: `DiskAnalyzerCore` de `disk_analyzer_core.py`; `DiskAnalyzer` de `disk_analyzer.py`
+- Produces: una suite que cualquier task posterior puede correr para detectar regresiones del refactor
+
+- [ ] **Step 1: Escribir los tests de tamaño y escaneo**
+
+Crear `tests/test_engine_characterization.py`:
+
+```python
+"""Characterization tests: pin the engine's CURRENT behavior before refactoring.
+
+These describe what the code does today, not what it ideally should do.
+A failure here during the shared-engine extraction means the refactor changed
+behavior — fix the refactor, not the test.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from disk_analyzer_core import DiskAnalyzerCore, KB, MB, GB
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A small, predictable directory tree."""
+    (tmp_path / "big.bin").write_bytes(b"x" * (3 * 1024 * 1024))   # 3 MB
+    (tmp_path / "small.txt").write_text("hello")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "nested.bin").write_bytes(b"y" * (2 * 1024 * 1024))     # 2 MB
+    ignored = tmp_path / "node_modules"
+    ignored.mkdir()
+    (ignored / "junk.bin").write_bytes(b"z" * (5 * 1024 * 1024))
+    return tmp_path
+
+
+class TestFormatSize:
+    def test_bytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(0) == "0.00 B"
+
+    def test_kilobytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(1536).endswith("KB")
+
+    def test_gigabytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(5 * GB).startswith("5.00")
+
+
+class TestScanDirectory:
+    def test_finds_large_files_above_min_size(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        names = {Path(f["path"]).name for f in core.large_files}
+        assert "big.bin" in names
+        assert "small.txt" not in names
+
+    def test_uses_real_disk_blocks_not_logical_size(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        entry = next(f for f in core.large_files if Path(f["path"]).name == "big.bin")
+        stat = (tree / "big.bin").stat()
+        expected = stat.st_blocks * 512 if hasattr(stat, "st_blocks") else stat.st_size
+        assert entry["size"] == expected
+
+    def test_skips_ignored_directories(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        paths = " ".join(f["path"] for f in core.large_files)
+        assert "node_modules" not in paths
+
+    def test_does_not_follow_symlinks(self, tmp_path):
+        target = tmp_path / "real"
+        target.mkdir()
+        (target / "file.bin").write_bytes(b"a" * (2 * 1024 * 1024))
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks not supported here")
+        core = DiskAnalyzerCore(str(tmp_path), min_size_mb=1)
+        core.scan_directory(tmp_path)
+        # The file is found once (through the real dir), not twice via the link
+        matches = [f for f in core.large_files if Path(f["path"]).name == "file.bin"]
+        assert len(matches) == 1
+
+    def test_records_file_type_stats(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        assert ".bin" in core.file_type_stats
+
+
+class TestProtectedPaths:
+    @pytest.mark.parametrize("path,expected", [
+        ("/System/Library/Kernels/kernel", True),
+        ("/usr/lib/libSystem.dylib", True),
+        ("/bin", True),
+        ("/sbin", True),
+        ("/Applications/Foo.app/Contents/MacOS/Foo", True),
+        ("/private/var/vm/sleepimage", True),
+        (str(Path.home() / "Downloads" / "movie.mp4"), False),
+        (str(Path.home() / "Library" / "Caches" / "something"), False),
+    ])
+    def test_protection_table(self, path, expected):
+        core = DiskAnalyzerCore(".")
+        assert core.is_protected_path(path) is expected
+
+    def test_prefix_match_not_substring(self):
+        """A path merely CONTAINING a protected prefix is not protected."""
+        core = DiskAnalyzerCore(".")
+        assert core.is_protected_path(str(Path.home() / "my/System/notes.txt")) is False
+```
+
+Nota: antes de escribir estos tests, leer las firmas reales de
+`DiskAnalyzerCore.__init__` (parámetros y sus nombres, por ejemplo si es
+`min_size_mb` u otro) y de `scan_directory`, y ajustar las llamadas. Si
+`format_size` devuelve otro formato exacto, ajustar los asserts a lo que
+devuelve hoy: el objetivo es fijar el comportamiento real, no imponer uno.
+
+- [ ] **Step 2: Escribir los tests de clasificación de cachés y recomendaciones**
+
+Añadir al mismo archivo:
+
+```python
+class TestCacheClassification:
+    """Pins the CURRENT labels of both implementations, which differ.
+
+    Task 4 unifies them; these tests are what proves the unification did not
+    silently drop a category.
+    """
+
+    @pytest.mark.parametrize("path,expected", [
+        (Path.home() / "Library/Caches/com.docker.docker", "Docker"),
+        (Path.home() / "Library/Developer/Xcode/DerivedData", "Xcode Cache"),
+        (Path.home() / "Library/Caches/com.microsoft.VSCode", "VS Code Cache"),
+        (Path.home() / ".npm", "NPM Cache"),
+        (Path.home() / ".Trash", "Papelera"),
+    ])
+    def test_core_labels(self, path, expected):
+        core = DiskAnalyzerCore(".")
+        assert core.categorize_cache(path) == expected
+
+    def test_cli_labels_differ_from_core(self):
+        """Documents the divergence Task 4 removes."""
+        from disk_analyzer import DiskAnalyzer
+        cli = DiskAnalyzer(".")
+        core = DiskAnalyzerCore(".")
+        vscode = Path.home() / "Library/Caches/com.microsoft.VSCode"
+        assert cli.classify_cache(vscode) == "VS Code"
+        assert core.categorize_cache(vscode) == "VS Code Cache"
+
+
+class TestRecommendations:
+    def test_recommendations_have_required_shape(self):
+        core = DiskAnalyzerCore(".")
+        core.cache_locations = [
+            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
+            {"path": "/fake/code", "size": 2 * GB, "type": "VS Code Cache"},
+        ]
+        recs = core.generate_recommendations()
+        assert recs, "expected recommendations for large known caches"
+        for rec in recs:
+            assert "type" in rec
+            assert "space" in rec
+            assert "tier" in rec
+
+    def test_recommendations_sorted_by_tier_then_size(self):
+        core = DiskAnalyzerCore(".")
+        core.cache_locations = [
+            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
+            {"path": "/fake/code", "size": 9 * GB, "type": "VS Code Cache"},
+        ]
+        recs = core.generate_recommendations()
+        tiers = [r["tier"] for r in recs]
+        assert tiers == sorted(tiers)
+```
+
+Nota: verificar con `grep -n "def generate_recommendations" -A 40
+disk_analyzer_core.py` las claves reales que produce (`type`, `space`, `tier`,
+`command`, …) y ajustar. Si el orden no resulta ser por tier, fijar el orden
+real, no el deseado.
+
+- [ ] **Step 3: Correr y confirmar que pasan contra el código actual**
+
+Run: `venv-web/bin/python -m pytest tests/test_engine_characterization.py -v`
+Expected: PASS. Estos tests describen el presente; si alguno falla, es que la
+suposición sobre el comportamiento actual era incorrecta — corregir el test
+para reflejar la realidad, y anotar la sorpresa en el reporte.
+
+- [ ] **Step 4: Suite completa y commit**
+
+Run: `venv-web/bin/python -m pytest tests/ -v` → 79 + los nuevos.
+
+```bash
+git add tests/test_engine_characterization.py
+git commit -m "test: red de caracterización del motor antes de extraer el módulo compartido"
+```
+
+---
+
+### Task 2: Extraer las constantes a `analyzer/constants.py`
+
+Movimiento puramente mecánico: las constantes son idénticas en valor entre los
+dos módulos. Sin cambio de comportamiento.
+
+**Files:**
+- Create: `analyzer/__init__.py`, `analyzer/constants.py`
+- Modify: `disk_analyzer.py` (bloque de constantes ~líneas 21-133), `disk_analyzer_core.py` (~líneas 20-115)
+- Test: `tests/test_engine_characterization.py` (añadir una comprobación)
+
+**Interfaces:**
+- Produces: `analyzer/constants.py` exportando `KB`, `MB`, `GB`, `SYSTEM`, `IS_WINDOWS`, `IS_MACOS`, `IS_LINUX`, `CACHE_DIRS`, `LARGE_FILE_EXTENSIONS`, `IGNORE_PATTERNS`, `MACOS_APFS_SKIP_DIRS`, `PROTECTED_PATH_PREFIXES`, `PROTECTED_APP_MARKERS`, `PROTECTED_FILENAMES`, `PROTECTED_ROOT_DIRS`
+- Los dos módulos siguen re-exportando lo que ya exportaban: `disk_analyzer_web.py` importa `MB, GB, IS_MACOS, IS_WINDOWS` desde `disk_analyzer_core`, y `disk_analyzer_gui.py` importa `MB, GB`. Esos imports deben seguir funcionando sin tocar esos archivos.
+
+- [ ] **Step 1: Crear el paquete**
+
+`analyzer/__init__.py`:
+
+```python
+"""Shared analysis engine, used by the CLI, the web backend and the GUI.
+
+Standard library only: the CLI must keep working without any pip install.
+"""
+```
+
+- [ ] **Step 2: Mover las constantes**
+
+Copiar el bloque de constantes **verbatim** desde `disk_analyzer.py` (líneas ~21
+a ~133) a `analyzer/constants.py`, con su encabezado de docstring. No reescribir
+valores ni reordenar entradas: es un movimiento, no una edición.
+
+Antes de mover, verificar con `diff` que los dos bloques son de verdad idénticos
+en valor:
+
+```bash
+venv-web/bin/python - <<'PY'
+import disk_analyzer as a, disk_analyzer_core as c
+for name in ["KB","MB","GB","CACHE_DIRS","LARGE_FILE_EXTENSIONS","IGNORE_PATTERNS",
+             "MACOS_APFS_SKIP_DIRS","PROTECTED_PATH_PREFIXES","PROTECTED_APP_MARKERS",
+             "PROTECTED_FILENAMES","PROTECTED_ROOT_DIRS"]:
+    va, vc = getattr(a, name, "<missing>"), getattr(c, name, "<missing>")
+    print(f"{name}: {'IGUAL' if va == vc else 'DISTINTO'}")
+    if va != vc:
+        print("   CLI :", va)
+        print("   CORE:", vc)
+PY
+```
+
+Si alguna sale `DISTINTO`, **parar y reportarlo**: el inventario decía que eran
+idénticas, y una diferencia cambia el alcance de este task.
+
+- [ ] **Step 3: Reemplazar las definiciones por imports**
+
+En `disk_analyzer.py` y `disk_analyzer_core.py`, sustituir el bloque de
+constantes por:
+
+```python
+from analyzer.constants import (
+    KB, MB, GB, SYSTEM, IS_WINDOWS, IS_MACOS, IS_LINUX,
+    CACHE_DIRS, LARGE_FILE_EXTENSIONS, IGNORE_PATTERNS, MACOS_APFS_SKIP_DIRS,
+    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
+    PROTECTED_ROOT_DIRS,
+)
+```
+
+Importante: ese `from ... import` deja los nombres disponibles a nivel de módulo,
+así que `from disk_analyzer_core import MB, GB, IS_MACOS, IS_WINDOWS` (lo que
+hace el backend web) sigue funcionando. Confirmarlo, no asumirlo.
+
+- [ ] **Step 4: Añadir la comprobación de que no hay dependencias externas**
+
+Añadir a `tests/test_engine_characterization.py`:
+
+```python
+class TestPackaging:
+    def test_analyzer_package_is_stdlib_only(self):
+        """The CLI must keep working without any pip install."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-c", "import analyzer.constants"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            env={**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)},
+        )
+        assert result.returncode == 0, result.stderr
+```
+
+- [ ] **Step 5: Verificar las tres interfaces y commitear**
+
+```bash
+venv-web/bin/python -m pytest tests/ -v
+venv-web/bin/python -c "import disk_analyzer, disk_analyzer_core, disk_analyzer_web; print('imports OK')"
+venv-web/bin/python disk_analyzer.py . --min-size 500 | head -20
+```
+Expected: la suite verde, los imports OK, y el CLI corriendo como antes.
+
+```bash
+git add analyzer/ disk_analyzer.py disk_analyzer_core.py tests/test_engine_characterization.py
+git commit -m "refactor: extraer las constantes compartidas a analyzer/constants.py"
+```
+
+---
+
+### Task 3: Extraer la protección de rutas a `analyzer/protection.py`
+
+`is_protected_path` es idéntico en los dos módulos. Además, el backend web hoy
+construye un `DiskAnalyzerCore` entero solo para llamarlo, lo cual es un rodeo
+que este task elimina.
+
+**Files:**
+- Create: `analyzer/protection.py`
+- Modify: `disk_analyzer.py`, `disk_analyzer_core.py`, `disk_analyzer_web.py`
+- Test: `tests/test_engine_characterization.py` (los tests de protección ya existen; añadir el de la función libre)
+
+**Interfaces:**
+- Produces: `analyzer.protection.is_protected_path(file_path: str) -> bool`, función libre
+- Los métodos `DiskAnalyzer.is_protected_path` y `DiskAnalyzerCore.is_protected_path` se conservan como delegación de una línea, para no romper a quien los llame
+
+- [ ] **Step 1: Crear el módulo**
+
+`analyzer/protection.py`: mover el cuerpo de `is_protected_path` (desde
+`disk_analyzer_core.py:191`, que es la versión sin comentarios) como función
+libre, importando las constantes de `analyzer.constants`. Copiar la lógica
+verbatim; no "mejorarla" de paso.
+
+- [ ] **Step 2: Delegar desde ambas clases**
+
+En las dos clases:
+
+```python
+    def is_protected_path(self, file_path: str) -> bool:
+        """Delegates to the shared implementation (kept for callers)."""
+        return protection.is_protected_path(file_path)
+```
+
+- [ ] **Step 3: Usar la función libre en el backend web**
+
+Buscar en `disk_analyzer_web.py` los sitios donde se instancia
+`DiskAnalyzerCore` únicamente para llamar a `is_protected_path` (hay al menos
+dos: el borrado de archivos y el bucle de borrado de cleanup) y sustituirlos por
+la función libre. Cuidado: dejar intactas las instancias que sí se usan para
+analizar.
+
+- [ ] **Step 4: Test de la función libre**
+
+Añadir a `tests/test_engine_characterization.py`:
+
+```python
+class TestProtectionModule:
+    def test_free_function_matches_method(self):
+        from analyzer.protection import is_protected_path
+        core = DiskAnalyzerCore(".")
+        for path in ["/System/Library/x", "/bin", str(Path.home() / "Downloads/a.mp4")]:
+            assert is_protected_path(path) == core.is_protected_path(path)
+```
+
+- [ ] **Step 5: Verificar y commitear**
+
+```bash
+venv-web/bin/python -m pytest tests/ -v
+git add analyzer/protection.py disk_analyzer.py disk_analyzer_core.py disk_analyzer_web.py tests/test_engine_characterization.py
+git commit -m "refactor: extraer is_protected_path a analyzer/protection.py"
+```
+
+---
+
+### Task 4: Unificar la clasificación de cachés
+
+El único task de esta fase con cambio de comportamiento real. Hoy hay dos
+clasificadores con etiquetas distintas, y tres consumidores que dependen de las
+cadenas exactas. Se unifican en uno solo.
+
+**Decisión de diseño (no relitigar):** se conserva el conjunto de etiquetas del
+**core** (el más granular, 12 categorías), porque es el que ven la web y la GUI,
+y porque las recomendaciones del core ya se alinearon a él en la Fase 1. El CLI
+pasa a usarlo. Las etiquetas quedan como constantes con nombre, no como cadenas
+sueltas repartidas por el código.
+
+**Files:**
+- Create: `analyzer/cache_types.py`
+- Modify: `disk_analyzer.py` (`classify_cache`, el safelist de `clean_cache`, `generate_recommendations`), `disk_analyzer_core.py` (`categorize_cache`, `generate_recommendations`)
+- Test: `tests/test_engine_characterization.py` (actualizar la clase de clasificación), `tests/test_cache_labels.py` (nuevo)
+
+**Interfaces:**
+- Produces: `analyzer/cache_types.py` con una constante por etiqueta (`DOCKER`, `XCODE`, `VSCODE`, `NPM`, `PYTHON`, `CHROME`, `FIREFOX`, `TRASH`, `TEMP`, `LOGS`, `DOWNLOADS`, `GENERAL`), el conjunto `SAFE_TO_CLEAN` que hoy codifica el safelist de `clean_cache`, y `classify(path: Path) -> str`
+- Ambas clases delegan su clasificador en `cache_types.classify`
+
+- [ ] **Step 1: Escribir el test que fija el contrato de los consumidores**
+
+Crear `tests/test_cache_labels.py`:
+
+```python
+"""The cache labels are a contract between the classifier and three consumers.
+
+Breaking it silently disables cleanup features — it already happened once
+(phase 1, task 3), so it gets its own test.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from analyzer import cache_types
+from disk_analyzer_core import DiskAnalyzerCore, GB
+
+
+def test_every_recommendation_filter_label_is_producible():
+    """Any label the recommendation logic filters on must be a real label."""
+    known = set(cache_types.ALL_LABELS)
+    core = DiskAnalyzerCore(".")
+    core.cache_locations = [
+        {"path": f"/fake/{label}", "size": 5 * GB, "type": label}
+        for label in known
+    ]
+    recs = core.generate_recommendations()
+    # With every known label present at 5 GB, the known-cache recommendations
+    # must fire — if a filter references a label that no longer exists, its
+    # recommendation silently disappears.
+    assert recs, "no recommendations fired for any known cache label"
+
+
+def test_safe_to_clean_labels_are_real():
+    assert cache_types.SAFE_TO_CLEAN, "safelist must not be empty"
+    for label in cache_types.SAFE_TO_CLEAN:
+        assert label in cache_types.ALL_LABELS, f"{label} is not a real label"
+
+
+def test_downloads_and_general_are_never_auto_cleanable():
+    """Deleting Downloads or an unclassified cache automatically is unsafe."""
+    assert cache_types.DOWNLOADS not in cache_types.SAFE_TO_CLEAN
+    assert cache_types.GENERAL not in cache_types.SAFE_TO_CLEAN
+```
+
+- [ ] **Step 2: Correr y verificar que falla**
+
+Run: `venv-web/bin/python -m pytest tests/test_cache_labels.py -v`
+Expected: FAIL con `ModuleNotFoundError: analyzer.cache_types`.
+
+- [ ] **Step 3: Crear el módulo de etiquetas**
+
+`analyzer/cache_types.py`:
+
+```python
+"""Cache category labels and classification.
+
+These label strings are a contract: the classifier produces them, and
+generate_recommendations (CLI and core), clean_cache's safelist and the web
+cleanup endpoint all match on them. Changing a string without updating every
+consumer silently disables a cleanup feature.
+"""
+from pathlib import Path
+
+DOCKER = 'Docker'
+XCODE = 'Xcode Cache'
+VSCODE = 'VS Code Cache'
+NPM = 'NPM Cache'
+PYTHON = 'Python Cache'
+CHROME = 'Chrome Cache'
+FIREFOX = 'Firefox Cache'
+TRASH = 'Papelera'
+TEMP = 'Archivos Temporales'
+LOGS = 'Logs del Sistema'
+DOWNLOADS = 'Downloads'
+GENERAL = 'Cache General'
+
+ALL_LABELS = (
+    DOCKER, XCODE, VSCODE, NPM, PYTHON, CHROME, FIREFOX,
+    TRASH, TEMP, LOGS, DOWNLOADS, GENERAL,
+)
+
+# Categories safe to delete without human review. Downloads holds user data and
+# GENERAL is by definition unclassified, so neither is ever auto-cleanable.
+SAFE_TO_CLEAN = frozenset({LOGS, VSCODE, NPM, XCODE, PYTHON, TEMP})
+
+
+def classify(path: Path) -> str:
+    """Classify a cache location by path. Order matters: first match wins."""
+    ...
+```
+
+El cuerpo de `classify` se porta **verbatim** desde
+`DiskAnalyzerCore.categorize_cache` (`disk_analyzer_core.py:403`), sustituyendo
+cada cadena literal por su constante. No cambiar la precedencia de las ramas:
+el orden es parte del comportamiento que fijan los tests de caracterización.
+
+Nota sobre `SAFE_TO_CLEAN`: leer el safelist actual de `clean_cache` en
+`disk_analyzer.py` (usa las etiquetas viejas del CLI: `'Logs del Sistema'`,
+`'VS Code'`, `'Node.js/npm'`, `'Xcode Development'`, `'Python Cache'`) y
+traducirlo a las etiquetas nuevas conservando **exactamente el mismo conjunto de
+categorías**, ni una más. Si alguna categoría vieja no tiene equivalente exacto,
+parar y reportarlo en vez de adivinar.
+
+- [ ] **Step 4: Delegar desde ambas clases y actualizar los consumidores**
+
+- `DiskAnalyzerCore.categorize_cache` → `return cache_types.classify(path)`
+- `DiskAnalyzer.classify_cache` → `return cache_types.classify(path)`
+- `clean_cache`: sustituir el safelist literal por `cache_types.SAFE_TO_CLEAN`
+- `generate_recommendations` en **ambos** módulos: sustituir cada comparación de
+  cadena por su constante
+
+Buscar los consumidores con:
+`grep -rn "VS Code\|Node.js/npm\|Xcode Development\|Cache General\|NPM Cache\|VS Code Cache" --include="*.py" .`
+y no dejar ninguna cadena literal de etiqueta fuera del módulo nuevo.
+
+- [ ] **Step 5: Actualizar el test de caracterización**
+
+La clase `TestCacheClassification` del Task 1 fija la divergencia entre los dos
+clasificadores. Este task la elimina a propósito, así que ese test **debe**
+actualizarse: `test_cli_labels_differ_from_core` pasa a afirmar que ahora
+coinciden. Renombrarlo a `test_cli_and_core_labels_now_match`. Es la única
+actualización de un test de caracterización autorizada en esta fase, y es
+deliberada.
+
+- [ ] **Step 6: Verificar y commitear**
+
+```bash
+venv-web/bin/python -m pytest tests/ -v
+venv-web/bin/python disk_analyzer.py . --min-size 500 --clean-cache --dry-run | head -30
+```
+Lo segundo debe listar categorías con las etiquetas nuevas y **no borrar nada**.
+
+```bash
+git add analyzer/cache_types.py disk_analyzer.py disk_analyzer_core.py tests/
+git commit -m "refactor: una sola clasificación de cachés con etiquetas como constantes"
+```
+
+---
+
+### Task 5: Reconciliar `get_directory_size` y el umbral de `find_cache_locations`
+
+Dos divergencias que dan resultados distintos para la misma entrada.
+
+**Decisiones de diseño (no relitigar):**
+- `get_directory_size` se queda con la versión del **core** (`rglob` +
+  `st_blocks`), porque es coherente con cómo el resto del motor mide el disco y
+  no depende de un subproceso. El CLI cambia. Consecuencia esperada: puede
+  reportar cifras ligeramente distintas a `du` en directorios con enlaces duros
+  o archivos dispersos; es el mismo criterio que ya usa el escaneo principal.
+- El umbral de `find_cache_locations` se queda en **`> MB`** (el del CLI): una
+  caché de 3 KB no es accionable y solo ensucia la lista. El core cambia.
+
+**Files:**
+- Modify: `disk_analyzer.py` (`get_directory_size`), `disk_analyzer_core.py` (umbral en `find_cache_locations`)
+- Test: `tests/test_engine_characterization.py`
+
+- [ ] **Step 1: Escribir los tests**
+
+```python
+class TestDirectorySize:
+    def test_matches_sum_of_block_sizes(self, tree):
+        core = DiskAnalyzerCore(str(tree))
+        from disk_analyzer import DiskAnalyzer
+        cli = DiskAnalyzer(str(tree))
+        # After reconciliation both implementations agree
+        assert cli.get_directory_size(tree) == core.get_directory_size(tree)
+
+
+class TestCacheThreshold:
+    def test_tiny_caches_are_not_reported(self, tmp_path, monkeypatch):
+        tiny = tmp_path / "tiny_cache"
+        tiny.mkdir()
+        (tiny / "a.txt").write_text("x")
+        import analyzer.constants as consts
+        monkeypatch.setattr(consts, "CACHE_DIRS", [str(tiny)], raising=False)
+        core = DiskAnalyzerCore(str(tmp_path))
+        core.find_cache_locations()
+        assert all(loc["size"] > 1024 * 1024 for loc in core.cache_locations)
+```
+
+Nota: `find_cache_locations` lee `CACHE_DIRS` — verificar cómo lo referencia
+(importado al espacio del módulo o vía `analyzer.constants`) y ajustar el
+monkeypatch al nombre real; si resulta difícil de interceptar, construir el test
+llamando directamente a la parte que aplica el umbral y decirlo en el reporte.
+
+- [ ] **Step 2: RED, luego implementar, luego GREEN**
+
+Reemplazar el cuerpo de `DiskAnalyzer.get_directory_size` por una delegación a
+la implementación compartida (moverla a `analyzer/` si conviene, o llamar a la
+del core), y cambiar `if size > 0:` por `if size > MB:` en
+`find_cache_locations` del core.
+
+- [ ] **Step 3: Verificar y commitear**
+
+```bash
+venv-web/bin/python -m pytest tests/ -v
+git add disk_analyzer.py disk_analyzer_core.py tests/test_engine_characterization.py
+git commit -m "refactor: una sola forma de medir directorios y un solo umbral de cachés"
+```
+
+---
+
+### Task 6: Verificación integral de la fase
+
+**Files:** ninguno nuevo.
+
+- [ ] **Step 1: Suite completa**
+
+Run: `venv-web/bin/python -m pytest tests/ -v` → verde.
+
+- [ ] **Step 2: Las tres interfaces, a mano**
+
+```bash
+# CLI: análisis y reporte
+venv-web/bin/python disk_analyzer.py . --min-size 100
+venv-web/bin/python disk_analyzer.py . --min-size 100 --export /tmp/fase3check --html
+# Backend web
+venv-web/bin/python -c "import disk_analyzer_web; print('web OK')"
+# GUI (puede faltar customtkinter; lo que importa es que no falle por el refactor)
+venv-web/bin/python -c "import disk_analyzer_gui" 2>&1 | tail -1
+```
+
+- [ ] **Step 3: Confirmar que el CLI sigue sin dependencias externas**
+
+```bash
+/usr/bin/python3 -c "import sys; sys.path.insert(0,'.'); import analyzer.constants, analyzer.protection, analyzer.cache_types; print('stdlib only OK')"
+```
+
+- [ ] **Step 4: Medir lo que se eliminó**
+
+```bash
+wc -l disk_analyzer.py disk_analyzer_core.py analyzer/*.py
+```
+Anotar el resultado en el registro de ejecución: la métrica de esta fase es
+cuánta duplicación desapareció.
+
+- [ ] **Step 5: Commit de verificación**
+
+```bash
+git add -A && git commit -m "test: verificación integral fase 3" --allow-empty
+```
+
+---
+
+## Fuera del alcance de esta fase
+
+Se dejan deliberadamente para después, porque cada una es un proyecto en sí:
+
+- **Mover `generate_html_report` y los Sankey** (~2.300 líneas) a un módulo de
+  reporte. Es la única razón por la que el backend web importa el monolito.
+- **Unificar `scan_directory`.** Las dos versiones comparten el conteo pero
+  difieren en el andamiaje (progreso por TTY con ETA en el CLI; callback,
+  cancelación y `max_depth` en el core). Unificarlas requiere diseñar una
+  interfaz de progreso común, y este plan ya toca bastante superficie.
+- **`get_all_drives`** (`List[str]` vs `List[Dict]`): cambiar la forma del CLI
+  afecta a `--all-drives` en Windows, que no se puede probar aquí.
+
+## Self-Review (ejecutado al escribir el plan)
+
+1. **Cobertura:** el objetivo era eliminar duplicación. Se cubren constantes,
+   protección, clasificación de cachés y las dos divergencias de medición. Lo que
+   queda fuera está declarado arriba con su motivo, no omitido en silencio.
+2. **Placeholders:** los pasos de movimiento mecánico dicen "portar verbatim" a
+   propósito — copiar líneas existentes es la acción, y transcribirlas aquí
+   invitaría a divergencias. Los tests sí llevan código completo.
+3. **Consistencia de tipos:** `is_protected_path(str) -> bool` igual que hoy;
+   `classify(Path) -> str` con el mismo dominio de salida que
+   `categorize_cache`; `SAFE_TO_CLEAN` es un `frozenset` de etiquetas que
+   `ALL_LABELS` contiene, comprobado por test.
+4. **Riesgo principal:** el Task 4 toca cadenas de las que depende
+   funcionalidad. Por eso lleva su propio archivo de tests de contrato y una
+   verificación manual en seco del CLI.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -7,14 +7,14 @@ cuál es la siguiente acción y cómo ejecutarla.
 
 ## Estado de un vistazo
 
-Última actualización: 15 de julio de 2026. Tests: **79 passed**.
+Última actualización: 31 de julio de 2026. Tests: **137 passed**.
 
 | Fase | Alcance | Plan | Estado |
 |---|---|---|---|
 | 0 | Higiene del repo (destrackear `.pyc`, borrar ~12 MB de reportes) | En el roadmap, sin plan TDD | Pendiente |
 | 1 | Bugs críticos del backend (6 fixes) | [Fase 1](2026-07-15-mejoras-fase1-bugs-criticos.md) | ✅ Completa, mergeada a `main` (PR #5) |
 | 2 | Seguridad (auth, CORS, agents, fds del PTY) | [Fase 2](2026-07-15-mejoras-fase2-seguridad.md) | ✅ Completa y verificada en `feat/fase2-seguridad`, sin mergear |
-| 3 | Motor compartido (deduplicar CLI vs core) | Solo esbozo en el roadmap | Pendiente |
+| 3 | Motor compartido (deduplicar CLI vs core) | [Fase 3](2026-07-30-mejoras-fase3-motor-compartido.md) | ✅ Completa y verificada en `feat/fase3-motor-compartido`, sin mergear |
 | 4 | Frontend (cleanup runner, sesiones, tipos, código muerto) | Solo esbozo en el roadmap | Pendiente |
 | 5 | Tests del motor y CI | Solo esbozo en el roadmap | Pendiente |
 
@@ -29,16 +29,26 @@ Documentos de referencia:
 
 ## Siguiente acción
 
-La Fase 2 está implementada y verificada en `feat/fase2-seguridad`, pero **sin
-mergear**: falta decidir si se abre un pull request hacia `main` (como se hizo
-con la Fase 1) o se sigue trabajando sobre la rama.
+Hay **dos ramas terminadas y sin mergear**, apiladas una sobre otra:
 
-Después de eso, la siguiente pieza de trabajo es escribir el plan detallado de
-una de las fases pendientes. Recomendación: la **Fase 3** (motor compartido),
-porque la duplicación entre `disk_analyzer.py` y `disk_analyzer_core.py` es la
-que hace que cada bug haya que arreglarlo dos veces. Su alcance está en el
-[roadmap](2026-07-15-roadmap-mejoras.md#fase-3--motor-compartido-plan-detallado-pendiente).
-La Fase 0 (higiene) son 15 minutos y no necesita plan.
+```
+main ← feat/fase2-seguridad ← feat/fase3-motor-compartido
+```
+
+La Fase 3 se ramificó desde la 2, así que contiene ambas. Decidir cómo
+integrarlas es lo primero: un pull request por fase (respetando el orden) o uno
+solo con las dos. Ambas están verificadas y con la suite en verde.
+
+Después de integrarlas, quedan pendientes de escribir su plan detallado la
+**Fase 4** (frontend) y la **Fase 5** (tests del motor y CI); su alcance está en
+el [roadmap](2026-07-15-roadmap-mejoras.md). La Fase 0 (higiene) son 15 minutos,
+no necesita plan, y requiere `sudo` porque hay archivos que quedaron propiedad
+de `root`.
+
+Hay además una decisión de producto pendiente, registrada en el
+[registro de ejecución](2026-07-15-registro-ejecucion.md#la-decisión-sobre-las-cachés-de-python):
+si `--clean-cache` debe borrar o no las cachés de Python. Hoy no las borra, que
+es lo que hacía antes.
 
 ## Cómo ejecutar un plan
 

--- a/tests/test_analyzer_package.py
+++ b/tests/test_analyzer_package.py
@@ -1,0 +1,21 @@
+"""Checks for the shared `analyzer` package extracted in Phase 3 Task 2.
+
+Kept in its own file (rather than test_engine_characterization.py) to avoid
+colliding with concurrent edits to that file.
+"""
+import os
+import sys
+from pathlib import Path
+
+
+class TestPackaging:
+    def test_analyzer_package_is_stdlib_only(self):
+        """The CLI must keep working without any pip install."""
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-c", "import analyzer.constants"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            env={**os.environ, "PYTHONPATH": str(Path(__file__).parent.parent)},
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_cache_labels.py
+++ b/tests/test_cache_labels.py
@@ -37,3 +37,22 @@ def test_downloads_and_general_are_never_auto_cleanable():
     """Deleting Downloads or an unclassified cache automatically is unsafe."""
     assert cache_types.DOWNLOADS not in cache_types.SAFE_TO_CLEAN
     assert cache_types.GENERAL not in cache_types.SAFE_TO_CLEAN
+
+
+def test_python_cache_is_not_auto_cleanable():
+    """PYTHON must stay OUT of SAFE_TO_CLEAN -- do not casually re-add it.
+
+    The pre-unification CLI safelist literally contained the string
+    'Python Cache', but the pre-unification CLI classifier never produced
+    that label (no python-specific branch), so it was dead text: python
+    caches always fell through to 'Cache General' and were never cleaned.
+    Now that the unified classifier has a real, reachable PYTHON branch,
+    adding it to SAFE_TO_CLEAN would newly enable deletion of python caches
+    -- and clean_cache's directory-deletion branch does a permanent
+    rglob().unlink() with NO move to Trash (see task-4-report.md, "Fix round
+    1"), so that deletion would be irreversible. This is deliberately
+    deferred to an explicit owner decision, not something a refactor should
+    introduce as a side effect. If you're re-adding PYTHON here, get that
+    decision first and delete this test as part of making it.
+    """
+    assert cache_types.PYTHON not in cache_types.SAFE_TO_CLEAN

--- a/tests/test_cache_labels.py
+++ b/tests/test_cache_labels.py
@@ -1,0 +1,39 @@
+"""The cache labels are a contract between the classifier and three consumers.
+
+Breaking it silently disables cleanup features — it already happened once
+(phase 1, task 3), so it gets its own test.
+"""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from analyzer import cache_types
+from disk_analyzer_core import DiskAnalyzerCore, GB
+
+
+def test_every_recommendation_filter_label_is_producible():
+    """Any label the recommendation logic filters on must be a real label."""
+    known = set(cache_types.ALL_LABELS)
+    core = DiskAnalyzerCore(".")
+    core.cache_locations = [
+        {"path": f"/fake/{label}", "size": 5 * GB, "type": label}
+        for label in known
+    ]
+    recs = core.generate_recommendations()
+    # With every known label present at 5 GB, the known-cache recommendations
+    # must fire — if a filter references a label that no longer exists, its
+    # recommendation silently disappears.
+    assert recs, "no recommendations fired for any known cache label"
+
+
+def test_safe_to_clean_labels_are_real():
+    assert cache_types.SAFE_TO_CLEAN, "safelist must not be empty"
+    for label in cache_types.SAFE_TO_CLEAN:
+        assert label in cache_types.ALL_LABELS, f"{label} is not a real label"
+
+
+def test_downloads_and_general_are_never_auto_cleanable():
+    """Deleting Downloads or an unclassified cache automatically is unsafe."""
+    assert cache_types.DOWNLOADS not in cache_types.SAFE_TO_CLEAN
+    assert cache_types.GENERAL not in cache_types.SAFE_TO_CLEAN

--- a/tests/test_cleanup_api.py
+++ b/tests/test_cleanup_api.py
@@ -74,10 +74,11 @@ class TestCleanupExecute:
             def find_cache_locations(self):
                 pass
 
-            def is_protected_path(self, path):
-                return path.startswith("/System")
-
         monkeypatch.setattr(disk_analyzer_web, "DiskAnalyzerCore", FakeAnalyzer)
+        # _perform_cleanup_deletes now calls the shared analyzer.protection.is_protected_path
+        # free function directly (imported into this module's namespace), instead of a
+        # DiskAnalyzerCore instance method -- patch it at its new call site.
+        monkeypatch.setattr(disk_analyzer_web, "is_protected_path", lambda path: path.startswith("/System"))
         resp = self.client.post(
             "/api/cleanup/execute",
             json={"paths": [str(tmp_path)], "dry_run": False},

--- a/tests/test_engine_characterization.py
+++ b/tests/test_engine_characterization.py
@@ -143,20 +143,24 @@ class TestProtectedPaths:
 
 
 class TestCacheClassification:
-    """Pins the CURRENT labels of both implementations, which differ.
+    """Task 4 unified both classifiers behind analyzer.cache_types.classify().
 
-    Task 4 unifies them; these tests are what proves the unification did not
-    silently drop a category.
+    These tests used to pin the pre-unification divergence between the CLI's
+    classify_cache and the core's categorize_cache (different label sets, and
+    a precedence bug in the core's classifier -- see below). That divergence
+    is now deliberately gone: this is the ONE authorized characterization-test
+    change in this phase, and it is intentional, not a regression.
     """
 
     @pytest.mark.parametrize("path,expected", [
         (Path.home() / "Library/Caches/com.docker.docker", "Docker"),
-        # NOTE: categorize_cache checks the 'code'/'vscode' substring BEFORE
-        # the 'xcode' substring, and "xcode" itself contains the substring
-        # "code". So DerivedData is misclassified as "VS Code Cache", never
-        # reaching the 'xcode' branch. This looks like a bug (see report) but
-        # is today's real behavior -- pinned here, not fixed here.
-        (Path.home() / "Library/Developer/Xcode/DerivedData", "VS Code Cache"),
+        # FIXED by Task 4 (was a real bug): categorize_cache used to check the
+        # 'code'/'vscode' substring BEFORE the 'xcode' substring, and "xcode"
+        # itself contains the substring "code". So DerivedData was
+        # misclassified as "VS Code Cache" and the 'xcode' branch was
+        # unreachable. analyzer.cache_types.classify() checks 'xcode' first,
+        # so this now correctly returns "Xcode Cache".
+        (Path.home() / "Library/Developer/Xcode/DerivedData", "Xcode Cache"),
         (Path.home() / "Library/Caches/com.microsoft.VSCode", "VS Code Cache"),
         (Path.home() / ".npm", "NPM Cache"),
         (Path.home() / ".Trash", "Papelera"),
@@ -165,25 +169,30 @@ class TestCacheClassification:
         core = DiskAnalyzerCore(".")
         assert core.categorize_cache(path) == expected
 
-    def test_cli_labels_differ_from_core(self):
-        """Documents the divergence Task 4 removes."""
+    def test_cli_and_core_labels_now_match(self):
+        """Was test_cli_labels_differ_from_core, which documented the
+        pre-unification divergence. Task 4 made both classes delegate to the
+        same analyzer.cache_types.classify(), so they now agree -- this test
+        is renamed and its assertion flipped on purpose."""
         from disk_analyzer import DiskAnalyzer
         cli = DiskAnalyzer(".")
         core = DiskAnalyzerCore(".")
         vscode = Path.home() / "Library/Caches/com.microsoft.VSCode"
-        assert cli.classify_cache(vscode) == "VS Code"
-        assert core.categorize_cache(vscode) == "VS Code Cache"
+        assert cli.classify_cache(vscode) == core.categorize_cache(vscode) == "VS Code Cache"
 
-    def test_cli_does_not_have_the_xcode_bug(self):
-        """The CLI checks 'xcode' before 'code'/'vscode', so it does NOT
-        misclassify DerivedData the way core.categorize_cache does. This is
-        the concrete divergence between the two implementations' precedence
-        order, not just their label spelling.
+    def test_xcode_bug_is_fixed_for_both_cli_and_core(self):
+        """Was test_cli_does_not_have_the_xcode_bug, which asserted the CLI's
+        OLD label ('Xcode Development') to document that only the CLI's
+        classifier had correct 'xcode'-before-'code' precedence. Task 4
+        unified both classifiers behind the fixed analyzer.cache_types.classify(),
+        so now BOTH correctly return the shared 'Xcode Cache' label -- the bug
+        is fixed everywhere, not just avoided in one implementation.
         """
         from disk_analyzer import DiskAnalyzer
         cli = DiskAnalyzer(".")
+        core = DiskAnalyzerCore(".")
         xcode = Path.home() / "Library/Developer/Xcode/DerivedData"
-        assert cli.classify_cache(xcode) == "Xcode Development"
+        assert cli.classify_cache(xcode) == core.categorize_cache(xcode) == "Xcode Cache"
 
 
 class TestRecommendations:

--- a/tests/test_engine_characterization.py
+++ b/tests/test_engine_characterization.py
@@ -1,0 +1,201 @@
+"""Characterization tests: pin the engine's CURRENT behavior before refactoring.
+
+These describe what the code does today, not what it ideally should do.
+A failure here during the shared-engine extraction means the refactor changed
+behavior -- fix the refactor, not the test.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from disk_analyzer_core import DiskAnalyzerCore, KB, MB, GB
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A small, predictable directory tree."""
+    (tmp_path / "big.bin").write_bytes(b"x" * (3 * 1024 * 1024))   # 3 MB
+    (tmp_path / "small.txt").write_text("hello")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "nested.bin").write_bytes(b"y" * (2 * 1024 * 1024))     # 2 MB
+    ignored = tmp_path / "node_modules"
+    ignored.mkdir()
+    (ignored / "junk.bin").write_bytes(b"z" * (5 * 1024 * 1024))
+    return tmp_path
+
+
+class TestFormatSize:
+    def test_bytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(0) == "0.00 B"
+
+    def test_kilobytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(1536).endswith("KB")
+
+    def test_gigabytes(self):
+        core = DiskAnalyzerCore(".")
+        assert core.format_size(5 * GB).startswith("5.00")
+
+
+class TestScanDirectory:
+    def test_finds_large_files_above_min_size(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        names = {Path(f["path"]).name for f in core.large_files}
+        assert "big.bin" in names
+        assert "small.txt" not in names
+
+    def test_uses_real_disk_blocks_not_logical_size(self, tree):
+        # Pad a file with a sparse hole so logical size and on-disk size
+        # provably diverge -- this makes the test fail loudly if scan_directory
+        # is ever changed to use st_size instead of st_blocks * 512.
+        sparse = tree / "sparse.bin"
+        with open(sparse, "wb") as fh:
+            fh.write(b"a" * (1024 * 1024))  # 1 MB of real data
+            fh.truncate(20 * 1024 * 1024)   # logical size 20 MB, mostly a hole
+
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        entry = next(f for f in core.large_files if Path(f["path"]).name == "sparse.bin")
+        stat = sparse.stat()
+        on_disk = stat.st_blocks * 512 if hasattr(stat, "st_blocks") else stat.st_size
+        assert entry["size"] == on_disk
+        # The whole point of using st_blocks: on a sparse file, on-disk size
+        # must be materially smaller than the logical size it was truncated to.
+        if hasattr(stat, "st_blocks"):
+            assert entry["size"] < stat.st_size
+
+    def test_skips_ignored_directories(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        paths = " ".join(f["path"] for f in core.large_files)
+        assert "node_modules" not in paths
+
+    def test_does_not_follow_symlinks(self, tmp_path):
+        target = tmp_path / "real"
+        target.mkdir()
+        (target / "file.bin").write_bytes(b"a" * (2 * 1024 * 1024))
+        link = tmp_path / "link"
+        try:
+            link.symlink_to(target, target_is_directory=True)
+        except OSError:
+            pytest.skip("symlinks not supported here")
+        core = DiskAnalyzerCore(str(tmp_path), min_size_mb=1)
+        core.scan_directory(tmp_path)
+        # The file is found once (through the real dir), not twice via the link
+        matches = [f for f in core.large_files if Path(f["path"]).name == "file.bin"]
+        assert len(matches) == 1
+
+    def test_records_file_type_stats(self, tree):
+        core = DiskAnalyzerCore(str(tree), min_size_mb=1)
+        core.scan_directory(tree)
+        assert ".bin" in core.file_type_stats
+
+
+class TestProtectedPaths:
+    @pytest.mark.parametrize("path,expected", [
+        ("/System/Library/Kernels/kernel", True),
+        ("/usr/lib/libSystem.dylib", True),
+        ("/bin", True),
+        ("/sbin", True),
+        ("/Applications/Foo.app/Contents/MacOS/Foo", True),
+        ("/private/var/vm/sleepimage", True),
+        (str(Path.home() / "Downloads" / "movie.mp4"), False),
+        (str(Path.home() / "Library" / "Caches" / "something"), False),
+    ])
+    def test_protection_table(self, path, expected):
+        core = DiskAnalyzerCore(".")
+        assert core.is_protected_path(path) is expected
+
+    def test_prefix_match_not_substring(self):
+        """A path merely CONTAINING a protected prefix is not protected."""
+        core = DiskAnalyzerCore(".")
+        assert core.is_protected_path(str(Path.home() / "my/System/notes.txt")) is False
+
+
+class TestCacheClassification:
+    """Pins the CURRENT labels of both implementations, which differ.
+
+    Task 4 unifies them; these tests are what proves the unification did not
+    silently drop a category.
+    """
+
+    @pytest.mark.parametrize("path,expected", [
+        (Path.home() / "Library/Caches/com.docker.docker", "Docker"),
+        # NOTE: categorize_cache checks the 'code'/'vscode' substring BEFORE
+        # the 'xcode' substring, and "xcode" itself contains the substring
+        # "code". So DerivedData is misclassified as "VS Code Cache", never
+        # reaching the 'xcode' branch. This looks like a bug (see report) but
+        # is today's real behavior -- pinned here, not fixed here.
+        (Path.home() / "Library/Developer/Xcode/DerivedData", "VS Code Cache"),
+        (Path.home() / "Library/Caches/com.microsoft.VSCode", "VS Code Cache"),
+        (Path.home() / ".npm", "NPM Cache"),
+        (Path.home() / ".Trash", "Papelera"),
+    ])
+    def test_core_labels(self, path, expected):
+        core = DiskAnalyzerCore(".")
+        assert core.categorize_cache(path) == expected
+
+    def test_cli_labels_differ_from_core(self):
+        """Documents the divergence Task 4 removes."""
+        from disk_analyzer import DiskAnalyzer
+        cli = DiskAnalyzer(".")
+        core = DiskAnalyzerCore(".")
+        vscode = Path.home() / "Library/Caches/com.microsoft.VSCode"
+        assert cli.classify_cache(vscode) == "VS Code"
+        assert core.categorize_cache(vscode) == "VS Code Cache"
+
+    def test_cli_does_not_have_the_xcode_bug(self):
+        """The CLI checks 'xcode' before 'code'/'vscode', so it does NOT
+        misclassify DerivedData the way core.categorize_cache does. This is
+        the concrete divergence between the two implementations' precedence
+        order, not just their label spelling.
+        """
+        from disk_analyzer import DiskAnalyzer
+        cli = DiskAnalyzer(".")
+        xcode = Path.home() / "Library/Developer/Xcode/DerivedData"
+        assert cli.classify_cache(xcode) == "Xcode Development"
+
+
+class TestRecommendations:
+    def test_recommendations_have_required_shape(self):
+        core = DiskAnalyzerCore(".")
+        core.cache_locations = [
+            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
+            {"path": "/fake/code", "size": 2 * GB, "type": "VS Code Cache"},
+        ]
+        recs = core.generate_recommendations()
+        assert recs, "expected recommendations for large known caches"
+        for rec in recs:
+            assert "type" in rec
+            assert "space" in rec
+            assert "tier" in rec
+
+    def test_recommendations_sorted_by_tier_then_size(self):
+        # Tier 1 total (12 GB) exceeds the Tier 2 Docker entry (a lone 20 GB
+        # reclaim) so a naive "sort by size" would put Docker first. Real
+        # sort key is (tier, -space): tier wins, size only breaks ties within
+        # a tier. This is what would break if someone "simplified" the sort
+        # to `key=lambda x: -x['space']` during the refactor.
+        core = DiskAnalyzerCore(".")
+        core.cache_locations = [
+            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
+            {"path": "/fake/code", "size": 9 * GB, "type": "VS Code Cache"},
+        ]
+        core.docker_stats = {"available": True, "reclaimable": 20 * GB}
+        recs = core.generate_recommendations()
+
+        tiers = [r["tier"] for r in recs]
+        assert tiers == sorted(tiers)
+        # Tier 1 items (smaller, combined) must all precede the larger Tier 2 item.
+        assert [r["type"] for r in recs] == ["Cache de VS Code", "Cache de npm", "Docker"]
+        # Within tier 1, the larger entry (VS Code, 9 GB) sorts before the
+        # smaller one (npm, 3 GB): descending by space, not insertion order.
+        tier1 = [r for r in recs if r["tier"] == 1]
+        assert [r["space"] for r in tier1] == sorted((r["space"] for r in tier1), reverse=True)

--- a/tests/test_engine_characterization.py
+++ b/tests/test_engine_characterization.py
@@ -118,6 +118,29 @@ class TestProtectedPaths:
         core = DiskAnalyzerCore(".")
         assert core.is_protected_path(str(Path.home() / "my/System/notes.txt")) is False
 
+    def test_full_prefix_as_inner_substring_not_protected(self):
+        """A path that embeds a COMPLETE protected-prefix string
+        ('/System/Library/') as an inner substring, without starting with it,
+        must not be protected. `my/System/notes.txt` above never contains a
+        full prefix string (only a partial '/System/' fragment), so it can't
+        catch a `startswith(prefix)` -> `prefix in file_path` regression --
+        this one can, because '/System/Library/' does appear verbatim inside
+        the path.
+        """
+        core = DiskAnalyzerCore(".")
+        path = str(Path.home() / "backup/System/Library/notes.txt")
+        assert core.is_protected_path(path) is False
+
+    def test_root_dir_as_inner_path_segment_not_protected(self):
+        """A path containing '/bin' as a non-root, inner path segment must
+        not be protected -- only an exact top-level '/bin' or '/sbin'
+        component counts. Catches a PROTECTED_ROOT_DIRS exact-match ->
+        substring regression that neither of the two tests above exercises.
+        """
+        core = DiskAnalyzerCore(".")
+        path = str(Path.home() / "trash/bin/file.txt")
+        assert core.is_protected_path(path) is False
+
 
 class TestCacheClassification:
     """Pins the CURRENT labels of both implementations, which differ.
@@ -183,10 +206,19 @@ class TestRecommendations:
         # sort key is (tier, -space): tier wins, size only breaks ties within
         # a tier. This is what would break if someone "simplified" the sort
         # to `key=lambda x: -x['space']` during the refactor.
+        #
+        # Sizes are picked so insertion order and sorted order DIFFER: the
+        # source code's TIER 1 block appends the VS Code Cache entry before
+        # the NPM Cache entry regardless of size (see generate_recommendations
+        # in disk_analyzer_core.py), so making npm the larger of the two
+        # means the correctly-sorted output (npm first, by size descending)
+        # is the *opposite* of append order. That is what makes this test
+        # able to catch `sorted(...)` being deleted outright, not just
+        # replaced with the wrong key -- verified by mutation (see report).
         core = DiskAnalyzerCore(".")
         core.cache_locations = [
-            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
-            {"path": "/fake/code", "size": 9 * GB, "type": "VS Code Cache"},
+            {"path": "/fake/npm", "size": 9 * GB, "type": "NPM Cache"},
+            {"path": "/fake/code", "size": 3 * GB, "type": "VS Code Cache"},
         ]
         core.docker_stats = {"available": True, "reclaimable": 20 * GB}
         recs = core.generate_recommendations()
@@ -194,8 +226,9 @@ class TestRecommendations:
         tiers = [r["tier"] for r in recs]
         assert tiers == sorted(tiers)
         # Tier 1 items (smaller, combined) must all precede the larger Tier 2 item.
-        assert [r["type"] for r in recs] == ["Cache de VS Code", "Cache de npm", "Docker"]
-        # Within tier 1, the larger entry (VS Code, 9 GB) sorts before the
-        # smaller one (npm, 3 GB): descending by space, not insertion order.
+        assert [r["type"] for r in recs] == ["Cache de npm", "Cache de VS Code", "Docker"]
+        # Within tier 1, the larger entry (npm, 9 GB) sorts before the
+        # smaller one (VS Code, 3 GB): descending by space, not insertion
+        # order (insertion order appends VS Code first).
         tier1 = [r for r in recs if r["tier"] == 1]
         assert [r["space"] for r in tier1] == sorted((r["space"] for r in tier1), reverse=True)

--- a/tests/test_engine_measurement.py
+++ b/tests/test_engine_measurement.py
@@ -1,0 +1,119 @@
+"""Task 5: reconcile the two divergent implementations of directory-size
+measurement (CLI's `du -sk` shell-out vs. core's `rglob` + `st_blocks` walk)
+and of the cache-size threshold in `find_cache_locations` (core reported
+`size > 0`, CLI reported `size > MB`).
+
+Before this task, the CLI and the core engine could give different answers
+for the exact same directory. These tests pin the reconciled behavior: one
+directory-size implementation shared by both, and one threshold (`> MB`,
+the CLI's, since a few-KB cache isn't actionable).
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from disk_analyzer_core import DiskAnalyzerCore, MB
+
+
+@pytest.fixture
+def tree(tmp_path):
+    """A small, predictable directory tree (mirrors the fixture used in
+    tests/test_engine_characterization.py, duplicated here on purpose so this
+    file has no import-time dependency on that file, which another task is
+    concurrently editing)."""
+    (tmp_path / "big.bin").write_bytes(b"x" * (3 * 1024 * 1024))   # 3 MB
+    (tmp_path / "small.txt").write_text("hello")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "nested.bin").write_bytes(b"y" * (2 * 1024 * 1024))    # 2 MB
+    return tmp_path
+
+
+class TestDirectorySize:
+    def test_cli_and_core_agree(self, tree):
+        """Same directory, same answer -- there must be exactly ONE way to
+        measure a directory's size, shared by both entry points."""
+        from disk_analyzer import DiskAnalyzer
+
+        core = DiskAnalyzerCore(str(tree))
+        cli = DiskAnalyzer(str(tree))
+
+        core_size = core.get_directory_size(tree)
+        cli_size = cli.get_directory_size(tree)
+
+        assert core_size > 0, "sanity check: the tree actually has bytes on disk"
+        assert cli_size == core_size
+
+    def test_cli_and_core_agree_with_a_hard_link(self, tree):
+        """Regular files alone weren't enough to prove this test can fail:
+        on APFS, `du -sk` and a naive rglob+st_blocks sum happen to land on
+        the exact same number for a tree with no hard links, no sparse
+        files, and no symlinks -- verified empirically before writing this
+        test. Hard links are where they provably diverge: `du` counts a
+        multiply-linked file's disk blocks ONCE (it dedupes by inode),
+        while a naive walk that sums every directory entry's st_blocks
+        counts the same physical blocks once per link. Before reconciliation
+        this made the CLI (`du`-based) and the core (`rglob`-based) disagree
+        on this exact tree. After reconciliation both delegate to the same
+        walk, so they now agree with EACH OTHER -- even though that shared
+        answer double-counts relative to the old `du`-based CLI number. See
+        the task report for the measured before/after difference.
+        """
+        try:
+            os.link(str(tree / "big.bin"), str(tree / "hardlink.bin"))
+        except OSError:
+            pytest.skip("hard links not supported on this filesystem")
+
+        from disk_analyzer import DiskAnalyzer
+
+        core = DiskAnalyzerCore(str(tree))
+        cli = DiskAnalyzer(str(tree))
+
+        assert cli.get_directory_size(tree) == core.get_directory_size(tree)
+
+
+class TestCacheThreshold:
+    """`find_cache_locations` reads CACHE_DIRS as a name bound at import time
+    into disk_analyzer_core's own module namespace via
+    `from analyzer.constants import CACHE_DIRS` -- NOT as an attribute access
+    on `analyzer.constants` at call time. So patching
+    `analyzer.constants.CACHE_DIRS` (as a naive monkeypatch might attempt)
+    would silently fail to intercept anything, since the function looks up
+    the module-local name `CACHE_DIRS`, already bound to the original list
+    object. The patch below targets `disk_analyzer_core.CACHE_DIRS` instead,
+    which is the name actually resolved inside the function.
+    """
+
+    def test_tiny_caches_are_not_reported(self, tmp_path, monkeypatch):
+        tiny = tmp_path / "tiny_cache"
+        tiny.mkdir()
+        (tiny / "a.txt").write_text("x")  # a handful of bytes, well under 1 MB
+
+        import disk_analyzer_core
+        monkeypatch.setattr(disk_analyzer_core, "CACHE_DIRS", [str(tiny)], raising=False)
+
+        core = DiskAnalyzerCore(str(tmp_path))
+        core.find_cache_locations()
+
+        assert core.cache_locations == []
+
+    def test_caches_above_threshold_are_still_reported(self, tmp_path, monkeypatch):
+        """Canary for the test above: proves the CACHE_DIRS patch actually
+        intercepts (otherwise the previous test would pass vacuously because
+        find_cache_locations never even looked at our fake tiny cache)."""
+        big = tmp_path / "big_cache"
+        big.mkdir()
+        (big / "a.bin").write_bytes(b"x" * (2 * MB))
+
+        import disk_analyzer_core
+        monkeypatch.setattr(disk_analyzer_core, "CACHE_DIRS", [str(big)], raising=False)
+
+        core = DiskAnalyzerCore(str(tmp_path))
+        core.find_cache_locations()
+
+        assert len(core.cache_locations) == 1
+        assert core.cache_locations[0]["size"] > MB

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -1,0 +1,76 @@
+"""Tests for the shared protection module (analyzer/protection.py).
+
+`is_protected_path` used to be duplicated verbatim in DiskAnalyzer and
+DiskAnalyzerCore. It now lives as a free function in analyzer/protection.py,
+with both classes delegating a one-line method to it. This file owns
+protection testing: it checks the free function directly, and checks that
+both class methods still agree with it (regression guard for the delegation).
+
+See tests/test_engine_characterization.py::TestProtectedPaths for the
+pre-existing table of behaviors pinned against DiskAnalyzerCore.is_protected_path
+-- that class is not duplicated here.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from analyzer.protection import is_protected_path
+from disk_analyzer_core import DiskAnalyzerCore
+from disk_analyzer import DiskAnalyzer
+
+
+class TestFreeFunctionMatchesMethods:
+    """Both classes must delegate to the free function without drift."""
+
+    @pytest.mark.parametrize("path", [
+        "/System/Library/x",
+        "/bin",
+        "/sbin",
+        "/usr/lib/libSystem.dylib",
+        "/Applications/Foo.app/Contents/MacOS/Foo",
+        "/private/var/vm/sleepimage",
+        str(Path.home() / "Downloads/a.mp4"),
+        str(Path.home() / "Library/Caches/something"),
+    ])
+    def test_core_method_matches_free_function(self, path):
+        core = DiskAnalyzerCore(".")
+        assert core.is_protected_path(path) == is_protected_path(path)
+
+    @pytest.mark.parametrize("path", [
+        "/System/Library/x",
+        "/bin",
+        "/Applications/Foo.app/Contents/MacOS/Foo",
+        str(Path.home() / "Downloads/a.mp4"),
+    ])
+    def test_cli_method_matches_free_function(self, path):
+        analyzer = DiskAnalyzer(".")
+        assert analyzer.is_protected_path(path) == is_protected_path(path)
+
+
+class TestFreeFunctionBehaviors:
+    """Direct assertions against the free function, independent of any class."""
+
+    @pytest.mark.parametrize("path", [
+        "/System/Library/Kernels/kernel",
+        "/usr/lib/libSystem.dylib",
+        "/private/var/vm/sleepimage",
+    ])
+    def test_system_prefixes_are_protected(self, path):
+        assert is_protected_path(path) is True
+
+    @pytest.mark.parametrize("path", ["/bin", "/sbin"])
+    def test_root_dirs_are_protected(self, path):
+        assert is_protected_path(path) is True
+
+    def test_app_contents_marker_is_protected(self):
+        assert is_protected_path("/Applications/Foo.app/Contents/MacOS/Foo") is True
+
+    @pytest.mark.parametrize("filename", ["sleepimage", "swapfile"])
+    def test_protected_filenames_anywhere(self, filename):
+        assert is_protected_path(str(Path.home() / "somewhere" / filename)) is True
+
+    def test_normal_user_file_is_not_protected(self):
+        assert is_protected_path(str(Path.home() / "Downloads" / "movie.mp4")) is False


### PR DESCRIPTION
## Summary

Fase 3 del plan de mejoras. `disk_analyzer.py` (CLI) y `disk_analyzer_core.py` (motor de web y GUI) mantenían copias separadas de la misma lógica, así que cada bug había que arreglarlo dos veces — y en la práctica no siempre se hacía. Esta rama extrae un paquete `analyzer/` compartido.

### Qué se unificó

| Antes | Ahora |
|---|---|
| Constantes duplicadas (`CACHE_DIRS`, `PROTECTED_*`, `IGNORE_PATTERNS`…) | `analyzer/constants.py` |
| `is_protected_path` en ambas clases, y el backend web instanciando el motor entero solo para llamarlo | `analyzer/protection.py` |
| Dos clasificadores de cachés con 8 y 12 etiquetas distintas | `analyzer/cache_types.py`, etiquetas como constantes |
| `du -sk` por subproceso en el CLI vs `rglob` + `st_blocks` en el core | `analyzer/measurement.py` |
| Umbral de cachés `> MB` en el CLI vs `> 0` en el core | `> MB` en ambos |

`disk_analyzer.py` 4.882 → 4.737 líneas; `disk_analyzer_core.py` 762 → 630; más 281 líneas de paquete compartido. El número neto importa menos que el hecho de que esas cosas ahora existen una sola vez. `analyzer/` es solo biblioteca estándar, verificado con el Python del sistema: el CLI sigue sin dependencias.

### Un bug real que destapó la red de tests

El motor **no tenía ni un solo test**. Escribirlos antes de mover nada era el primer paso del plan, y encontró esto: `categorize_cache` evaluaba `'code' in path_str` antes que `'xcode'`, y como "code" es substring de "xcode", toda ruta de Xcode se clasificaba como `'VS Code Cache'` y la rama de Xcode era código muerto. Los usuarios de web y GUI veían sus cachés de Xcode mal etiquetadas y la recomendación específica de Xcode nunca disparaba. El CLI lo hacía bien. Corregido al unificar.

### Una decisión de comportamiento, tomada explícitamente

El safelist viejo del CLI contenía `'Python Cache'`, pero su clasificador nunca producía esa etiqueta: texto muerto, así que esas cachés no se limpiaban nunca. Al unificar habrían pasado a ser borrables por primera vez.

Se decidió **excluirlas**. La justificación inicial para permitirlo (que `clean_cache` manda a la Papelera y pide confirmación) resultó falsa al verificar el código: la Papelera solo aplica a archivos sueltos; para directorios —que es lo que son las cachés de Python— hace `unlink()` permanente, y la confirmación es una sola para todo el lote. Queda como decisión explícita del dueño, no como efecto colateral de un refactor.

### Hallazgo pendiente

`clean_cache` borra directorios de forma permanente para **todas** las categorías del safelist, contradiciendo su propio comentario "Mover a Trash en macOS". Documentado para una fase posterior.

## Test plan

- `python -m pytest tests/ -v` → **137 passed** (79 al empezar la fase; de 6 a 17 archivos de test)
- Las tres interfaces a mano: análisis y export HTML del CLI, import del backend web, imports de la GUI
- `analyzer/` importable con `/usr/bin/python3` sin venv (stdlib-only)

Diferencia medida por el cambio de medición: sobre este repo, +3,29 % frente a `du`, porque `du` cuenta los enlaces duros una vez y el recorrido los cuenta por cada entrada (npm los crea en `node_modules`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)