### PR TITLE
feat: la app de bandeja deja de necesitar el repositorio y pasa a ser distribuible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,8 @@ desktop/dist/
 *.cer
 *.certSigningRequest
 
-# Motor autocontenido: ~46 MB regenerables con desktop/tools/preparar-motor.sh
-desktop/src-tauri/resources/
+# Motor autocontenido: ~46 MB regenerables con desktop/tools/preparar-motor.sh.
+# El LEEME.md sí se versiona: Tauri aborta la compilación si el glob de
+# `bundle.resources` no encaja con ningún fichero, así que hace de ancla.
+desktop/src-tauri/resources/engine/*
+!desktop/src-tauri/resources/engine/LEEME.md

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ desktop/dist/
 *.p12
 *.cer
 *.certSigningRequest
+
+# Motor autocontenido: ~46 MB regenerables con desktop/tools/preparar-motor.sh
+desktop/src-tauri/resources/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,12 +170,18 @@ The project has three interfaces: CLI, GUI, and Web.
   `analisis.rs` (runs the Python engine as a child process), `lib.rs` (tray, menu, poller)
 - **Build:** `cd desktop && npm run tauri build -- --bundles app`
 - **Tests:** `cargo test --manifest-path desktop/src-tauri/Cargo.toml` (also run by `make test`)
-- **Two things that will surprise you:** the app is **not self-contained** — it
-  invokes `venv-web/bin/python` by absolute path, so moving the repo breaks the
-  analysis (the disk indicator keeps working). And it is **unsigned**, so
-  Gatekeeper blocks a double click (right-click → Open) and the Full Disk Access
-  grant breaks on every rebuild. Both have runbook entries:
-  `docs/runbooks/app-bandeja.md`.
+- **Bundled engine:** the `.app` ships its own trimmed CPython
+  (python-build-standalone) plus a copy of the engine, so it needs neither this
+  repo nor a system Python. Those ~47 MB are **not in git** — run
+  `./desktop/tools/preparar-motor.sh` before `npm run tauri build`, or the
+  `.app` builds without an engine.
+- **Two things that will surprise you:** the app falls back to
+  `venv-web/bin/python` when no bundled engine is found, which means a broken
+  packaging looks fine on a dev machine — check with
+  `ps -ax -o command | grep disk_analyzer.py` which interpreter actually runs.
+  And it is **unsigned** (arm64 only), so Gatekeeper blocks a double click
+  (right-click → Open) and the Full Disk Access grant breaks on every rebuild.
+  Both have runbook entries: `docs/runbooks/app-bandeja.md`.
 - `analisis.rs` uses POSIX process groups and signals, so it **only compiles on Unix**.
 
 ### GUI (CustomTkinter, legacy)

--- a/desktop/src-tauri/resources/engine/LEEME.md
+++ b/desktop/src-tauri/resources/engine/LEEME.md
@@ -1,0 +1,21 @@
+# Motor de análisis empaquetado
+
+Este directorio lo llena `desktop/tools/preparar-motor.sh`, que descarga un
+CPython de [python-build-standalone](https://github.com/astral-sh/python-build-standalone),
+lo recorta y le copia al lado el motor de análisis de este repositorio.
+
+Son unos 47 MB de binarios, así que **no se versionan**: se regeneran. Este
+`LEEME.md` es la excepción, y está versionado a propósito — Tauri aborta la
+compilación si el glob de `bundle.resources` no encaja con ningún fichero, así
+que sin él no se podría compilar la app en un checkout limpio (ni en el CI).
+
+Para preparar el motor antes de compilar:
+
+```bash
+./desktop/tools/preparar-motor.sh
+cd desktop && npm run tauri build -- --bundles app
+```
+
+Si te saltas ese paso, la `.app` se construye igual pero sin motor: el indicador
+de disco funciona con normalidad y "Analizar ahora" sale apagado, con el texto
+"Motor de análisis no encontrado" en el menú.

--- a/desktop/src-tauri/src/analisis.rs
+++ b/desktop/src-tauri/src/analisis.rs
@@ -75,19 +75,71 @@ impl Resultado {
     }
 }
 
-/// Resolves the repository root at compile time, relative to this crate's
-/// manifest directory (`desktop/src-tauri`), then canonicalizes it at
-/// runtime. This works only because the app runs on the same machine (and
-/// checkout) it was built on -- there is no bundled Python engine yet (see
-/// the module doc: every PyInstaller sidecar build was quarantined as
-/// malware). `tests/consistency.rs` already relies on this exact same
-/// resolution for the same reason, so both pieces would break together if
-/// the checkout ever moved relative to the crate.
-fn repo_root() -> PathBuf {
+/// Where the analysis engine lives, once resolved.
+#[derive(Debug, Clone)]
+pub struct Motor {
+    python: PathBuf,
+    script: PathBuf,
+    /// Working directory for the child. Python puts the script's directory on
+    /// `sys.path` by itself, so running from here is what lets the engine
+    /// import its own `analyzer/` package.
+    cwd: PathBuf,
+}
+
+/// The repository this crate was compiled from, if it is still there.
+///
+/// Returns `None` rather than panicking: inside a bundled `.app` the path
+/// baked in at compile time usually does not exist at all, and the tray
+/// indicator must survive that -- it does not need Python for anything.
+fn repo_root() -> Option<PathBuf> {
     Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .canonicalize()
-        .expect("repo root should exist relative to the crate manifest")
+        .ok()
+}
+
+/// Finds the analysis engine, preferring the copy bundled inside the `.app`.
+///
+/// That bundled copy is what makes the app self-contained and distributable:
+/// a trimmed CPython from python-build-standalone plus the engine sources,
+/// assembled by `desktop/tools/preparar-motor.sh`. The fallback to the
+/// repository's own venv keeps `npm run tauri dev` working without having to
+/// run that script first.
+pub fn localizar_motor(resource_dir: Option<PathBuf>) -> Option<Motor> {
+    if let Some(dir) = resource_dir {
+        // Tauri conserva la ruta relativa declarada en `bundle.resources`,
+        // así que `resources/engine/**/*` acaba en
+        // `Contents/Resources/resources/engine/` -- con el prefijo repetido.
+        // Verificado sobre una .app construida de verdad: buscar solo
+        // `engine/` no encontraba nada, y en la máquina de desarrollo el
+        // fallo pasaba desapercibido porque la reserva al venv del
+        // repositorio lo tapaba. En una máquina sin el repositorio la app
+        // habría dicho "motor no encontrado".
+        for candidato in ["resources/engine", "engine"] {
+            let engine = dir.join(candidato);
+            let python = engine.join("python/bin/python3");
+            let script = engine.join("disk_analyzer.py");
+            if python.is_file() && script.is_file() {
+                return Some(Motor {
+                    python,
+                    script,
+                    cwd: engine,
+                });
+            }
+        }
+    }
+
+    let repo = repo_root()?;
+    let python = repo.join("venv-web/bin/python");
+    let script = repo.join("disk_analyzer.py");
+    if python.is_file() && script.is_file() {
+        return Some(Motor {
+            python,
+            script,
+            cwd: repo,
+        });
+    }
+    None
 }
 
 /// Tracks at most one in-flight scan. `pid` is the single source of truth
@@ -100,14 +152,23 @@ fn repo_root() -> PathBuf {
 pub struct AnalisisManager {
     pid: Mutex<Option<i32>>,
     cancelado: AtomicBool,
+    motor: Option<Motor>,
 }
 
 impl AnalisisManager {
-    pub fn new() -> Self {
+    pub fn new(motor: Option<Motor>) -> Self {
         Self {
             pid: Mutex::new(None),
             cancelado: AtomicBool::new(false),
+            motor,
         }
+    }
+
+    /// Whether an engine was found at startup. The menu uses this to say so
+    /// up front instead of only failing when the user clicks "Analizar
+    /// ahora".
+    pub fn hay_motor(&self) -> bool {
+        self.motor.is_some()
     }
 
     pub fn is_running(&self) -> bool {
@@ -131,7 +192,11 @@ impl AnalisisManager {
         if self.is_running() {
             return Err("ya hay un análisis en marcha".to_string());
         }
-        self.start_con(comando_analisis()?, on_finish)
+        let motor = self
+            .motor
+            .as_ref()
+            .ok_or_else(|| "no se encontró el motor de análisis".to_string())?;
+        self.start_con(comando_analisis(motor)?, on_finish)
     }
 
     /// The half of `start` that does not know how to build the real scan
@@ -247,7 +312,7 @@ impl AnalisisManager {
 
 impl Default for AnalisisManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
@@ -265,10 +330,7 @@ struct Comando {
 static SECUENCIA: AtomicU64 = AtomicU64::new(0);
 
 /// Builds the real whole-disk scan command.
-fn comando_analisis() -> Result<Comando, String> {
-    let repo = repo_root();
-    let python = repo.join("venv-web/bin/python");
-    let script = repo.join("disk_analyzer.py");
+fn comando_analisis(motor: &Motor) -> Result<Comando, String> {
     let etiqueta = format!(
         "{}-{}",
         std::process::id(),
@@ -279,9 +341,9 @@ fn comando_analisis() -> Result<Comando, String> {
     let stderr_file = std::fs::File::create(&stderr_path)
         .map_err(|e| format!("no se pudo preparar el registro de errores: {e}"))?;
 
-    let mut cmd = Command::new(&python);
-    cmd.current_dir(&repo)
-        .arg(&script)
+    let mut cmd = Command::new(&motor.python);
+    cmd.current_dir(&motor.cwd)
+        .arg(&motor.script)
         .arg(SCAN_PATH)
         .arg("--min-size")
         .arg(MIN_SIZE_MB)
@@ -442,7 +504,7 @@ mod tests {
 
     #[test]
     fn cancelar_mata_el_grupo_entero_y_reporta_cancelado() {
-        let manager = Arc::new(AnalisisManager::new());
+        let manager = Arc::new(AnalisisManager::new(None));
         let (tx, rx) = mpsc::channel();
         let (comando, marca) = comando_de_prueba();
         manager
@@ -473,7 +535,7 @@ mod tests {
 
     #[test]
     fn kill_blocking_no_deja_huerfanos_al_salir() {
-        let manager = Arc::new(AnalisisManager::new());
+        let manager = Arc::new(AnalisisManager::new(None));
         let (comando, marca) = comando_de_prueba();
         manager
             .start_con(comando, |_| {})
@@ -496,7 +558,7 @@ mod tests {
 
     #[test]
     fn un_segundo_analisis_no_arranca_mientras_hay_uno_en_marcha() {
-        let manager = Arc::new(AnalisisManager::new());
+        let manager = Arc::new(AnalisisManager::new(None));
         let (comando, marca) = comando_de_prueba();
         manager
             .start_con(comando, |_| {})
@@ -511,6 +573,61 @@ mod tests {
 
         manager.kill_blocking();
         assert!(esperar_grupo_muerto(pgid));
+    }
+
+    /// El motor empaquetado tiene que ganarle al del repositorio. Si se
+    /// invirtiera la prioridad, la .app instalada seguiría dependiendo del
+    /// checkout de quien la compiló -- que es exactamente lo que este
+    /// empaquetado existe para arreglar, y no se notaría en la máquina de
+    /// desarrollo, donde ambos existen y los dos funcionan.
+    /// Reproduce la disposición que Tauri produce de verdad dentro de la
+    /// .app: el prefijo `resources/` se conserva, así que el motor queda en
+    /// `Contents/Resources/resources/engine/`. Este test existe porque la
+    /// primera versión buscaba solo en `engine/` y en esta máquina el fallo
+    /// quedaba tapado por la reserva al venv del repositorio.
+    #[test]
+    fn encuentra_el_motor_en_la_disposicion_real_de_tauri() {
+        let base = ruta_temporal("recursos-tauri");
+        let engine = base.join("resources/engine");
+        std::fs::create_dir_all(engine.join("python/bin")).unwrap();
+        std::fs::write(engine.join("python/bin/python3"), "#!/bin/sh\n").unwrap();
+        std::fs::write(engine.join("disk_analyzer.py"), "").unwrap();
+
+        let motor = localizar_motor(Some(base.clone()))
+            .expect("debería encontrar el motor donde Tauri lo pone de verdad");
+        assert!(
+            motor.python.starts_with(&base),
+            "cayó a la reserva del repositorio en vez de usar el motor empaquetado"
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn el_motor_empaquetado_gana_al_del_repositorio() {
+        let base = ruta_temporal("recursos");
+        let engine = base.join("engine");
+        std::fs::create_dir_all(engine.join("python/bin")).unwrap();
+        std::fs::write(engine.join("python/bin/python3"), "#!/bin/sh\n").unwrap();
+        std::fs::write(engine.join("disk_analyzer.py"), "").unwrap();
+
+        let motor = localizar_motor(Some(base.clone())).expect("debería encontrarlo");
+        assert!(
+            motor.python.starts_with(&base),
+            "eligió {:?} en vez del motor empaquetado",
+            motor.python
+        );
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn sin_motor_empaquetado_ni_repositorio_no_hay_motor() {
+        let vacio = ruta_temporal("vacio");
+        std::fs::create_dir_all(&vacio).unwrap();
+        // Con un directorio de recursos vacío cae al repositorio, que en esta
+        // máquina sí existe; lo que se comprueba es que no explota.
+        let _ = localizar_motor(Some(vacio.clone()));
+        assert!(!AnalisisManager::new(None).hay_motor());
+        let _ = std::fs::remove_dir_all(&vacio);
     }
 
     #[test]

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -122,12 +122,27 @@ pub fn run() {
                 ],
             )?;
 
-            let manager = Arc::new(AnalisisManager::new());
+            // El motor empaquetado dentro de la .app es el que hace que la
+            // app sea autocontenida; si no está (modo desarrollo), se cae al
+            // venv del repositorio.
+            let motor = analisis::localizar_motor(app.path().resource_dir().ok());
+            let hay_motor = motor.is_some();
+            let manager = Arc::new(AnalisisManager::new(motor));
             // Managed state so the shutdown handler in `run()` below (which
             // runs outside `setup` and has no closure access to `manager`)
             // can still reach it to guarantee cleanup on any exit path, not
             // just the "quit" menu item.
             app.manage(Arc::clone(&manager));
+
+            // Decirlo desde el arranque, no solo al pulsar: sin motor, el
+            // indicador de disco sigue siendo perfectamente útil, así que la
+            // app no se rompe -- pero el usuario tiene que saber por qué esa
+            // opción está apagada.
+            if !hay_motor {
+                let _ = analizar_item.set_enabled(false);
+                let _ = estado_analisis_item
+                    .set_text("Motor de análisis no encontrado");
+            }
 
             let mut tray_builder = TrayIconBuilder::new().menu(&menu).show_menu_on_left_click(true);
             match estado_inicial.map(icono_para) {

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -22,6 +22,9 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/engine/**/*"
     ]
   }
 }

--- a/desktop/tools/preparar-motor.sh
+++ b/desktop/tools/preparar-motor.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Prepara el motor de análisis autocontenido que se empaqueta dentro de la .app.
+#
+# Descarga un CPython de python-build-standalone, lo recorta y le copia al lado
+# el motor de este repositorio. El resultado va a
+# `desktop/src-tauri/resources/engine/`, que está en .gitignore: son ~46 MB de
+# binarios que no tienen por qué vivir en el historial de git. Se regenera con
+# este script y viaja dentro del artefacto del release.
+#
+# Por qué python-build-standalone y no PyInstaller: PyInstaller quedó descartado
+# porque su bootloader autoextraíble dispara la heurística de los antivirus (ver
+# el registro de ejecución). Esto es un CPython normal y sin modificar —el mismo
+# que usa `uv`—, así que no tiene ese problema. Verificado en la máquina que lo
+# sufrió.
+set -euo pipefail
+
+VERSION="20260814"
+PY_VERSION="3.13.15"
+ARCH="$(uname -m)"
+case "$ARCH" in
+  arm64)  TRIPLE="aarch64-apple-darwin" ;;
+  x86_64) TRIPLE="x86_64-apple-darwin" ;;
+  *) echo "Arquitectura no soportada: $ARCH" >&2; exit 1 ;;
+esac
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DESTINO="$REPO_ROOT/desktop/src-tauri/resources/engine"
+URL="https://github.com/astral-sh/python-build-standalone/releases/download/${VERSION}/cpython-${PY_VERSION}%2B${VERSION}-${TRIPLE}-install_only.tar.gz"
+
+echo "▸ Preparando el motor para $TRIPLE (CPython $PY_VERSION)"
+rm -rf "$DESTINO"
+mkdir -p "$DESTINO"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+echo "▸ Descargando CPython autocontenido (~25 MB)…"
+curl -fsSL -o "$TMP/cpython.tar.gz" "$URL"
+tar xzf "$TMP/cpython.tar.gz" -C "$TMP"
+mv "$TMP/python" "$DESTINO/python"
+
+# Recorte: nada de esto lo usa el motor, y son ~20 MB.
+echo "▸ Recortando lo que el motor no usa…"
+cd "$DESTINO/python"
+rm -rf lib/tcl9.0 lib/tcl8 lib/*tcl* lib/*tk* \
+       lib/python3.13/tkinter lib/python3.13/idlelib lib/python3.13/test \
+       lib/python3.13/lib2to3 lib/python3.13/ensurepip \
+       lib/python3.13/site-packages/pip* lib/python3.13/config-3.13-darwin \
+       include share lib/pkgconfig
+find . -name "__pycache__" -type d -prune -exec rm -rf {} + 2>/dev/null || true
+find . -name "*.a" -delete
+rm -f lib/python3.13/lib-dynload/_tkinter*.so
+
+# El motor, junto al intérprete. `disk_analyzer.py` queda en la raíz de engine/,
+# así que Python mete ese directorio en sys.path solo y encuentra `analyzer/`.
+echo "▸ Copiando el motor…"
+cd "$REPO_ROOT"
+cp disk_analyzer.py disk_analyzer_core.py "$DESTINO/"
+cp -R analyzer "$DESTINO/analyzer"
+find "$DESTINO/analyzer" -name "__pycache__" -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+echo "▸ Comprobando que arranca…"
+"$DESTINO/python/bin/python3" -c "
+import sys; sys.path.insert(0, '$DESTINO')
+from disk_analyzer_core import DiskAnalyzerCore
+d = DiskAnalyzerCore('.').get_disk_usage()
+assert d['total'] > 0
+print('  ✓ motor operativo:', round(d['total']/1024**3, 1), 'GB totales')
+"
+echo "▸ Listo: $DESTINO ($(du -sh "$DESTINO" | cut -f1))"

--- a/docs/runbooks/app-bandeja.md
+++ b/docs/runbooks/app-bandeja.md
@@ -9,24 +9,61 @@ desinstalarla del todo y volver atrás cuando algo sale mal.
   `desktop/src-tauri/target/release/bundle/macos/Disk Use Analyzer.app`
 - **Código:** `desktop/src-tauri/src/` (`disk.rs`, `estado.rs`, `analisis.rs`, `lib.rs`)
 
-## Lo que esta versión NO es todavía
+## Qué lleva dentro, y qué le falta
 
-**La app no es autocontenida y no se puede distribuir.** Al pulsar "Analizar
-ahora" ejecuta el intérprete del repositorio por ruta absoluta:
+La `.app` es **autocontenida**: pesa unos 92 MB porque lleva su propio CPython
+—una compilación de [python-build-standalone](https://github.com/astral-sh/python-build-standalone),
+recortada— y una copia del motor de análisis. No necesita este repositorio, ni
+`venv-web`, ni ningún Python instalado en el sistema. Se puede mover a otro Mac.
 
+Lo que sí le falta: **no está firmada ni notarizada** (decisión D4, sin cuenta de
+desarrollador de Apple). Gatekeeper la bloquea con doble clic; hay que abrirla la
+primera vez con clic derecho → **Abrir**. Y es **solo para Apple Silicon**
+(`arm64`); no hay build para Intel.
+
+### Regenerar el motor empaquetado
+
+Los ~47 MB del motor **no están en git**: se regeneran. Antes de compilar:
+
+```bash
+./desktop/tools/preparar-motor.sh
+cd desktop && npm run tauri build -- --bundles app
 ```
-<repo>/venv-web/bin/python <repo>/disk_analyzer.py / --min-size 50 --export <temporal>
+
+El script descarga el CPython, lo recorta y le copia al lado `disk_analyzer.py`,
+`disk_analyzer_core.py` y `analyzer/`. Si te saltas ese paso, la `.app` se
+construye igual pero sin motor: el indicador de disco funciona y "Analizar ahora"
+sale apagado con el texto "Motor de análisis no encontrado".
+
+### Por qué no PyInstaller
+
+Fue el primer intento y quedó descartado: el antivirus de esta máquina puso en
+cuarentena los tres binarios que produjo, con una firma genérica de malware. Es
+un falso positivo conocido de su *bootloader* autoextraíble, que está presente
+tanto en `--onefile` como en `--onedir` — cambiar de modo no habría servido de
+nada. `python-build-standalone` es un CPython normal y sin modificar, sin
+autoextraíble, y pasó sin incidentes en la misma máquina.
+
+### Dónde busca el motor la app
+
+Por orden:
+
+1. `Contents/Resources/resources/engine/` dentro de la `.app` (el prefijo
+   `resources/` aparece dos veces porque Tauri conserva la ruta relativa
+   declarada en `bundle.resources`).
+2. `venv-web/bin/python` del repositorio desde el que se compiló, para que
+   `npm run tauri dev` funcione sin preparar el motor.
+
+Esa reserva es cómoda y **traicionera**: en la máquina de desarrollo tapa un
+empaquetado roto, porque la app funciona igual tirando del repositorio. Para
+comprobar de verdad qué motor está usando, lanza un análisis y mira:
+
+```bash
+ps -ax -o command | grep disk_analyzer.py | grep -v grep
 ```
 
-Si mueves o borras el repositorio, o borras `venv-web/`, el análisis deja de
-funcionar y el menú lo dice ("no se pudo iniciar el motor de análisis"). El
-indicador de disco, en cambio, sigue funcionando: no depende de Python.
-
-El motivo está documentado en el plan de la rebanada A: empaquetar el motor con
-PyInstaller quedó descartado porque el antivirus de esta máquina puso en
-cuarentena los tres binarios producidos. Los dos caminos abiertos para arreglarlo
-—`python-build-standalone` y firmar con Developer ID— están en ese mismo
-documento.
+Si la ruta empieza por la `.app`, el empaquetado está bien. Si empieza por el
+repositorio, la `.app` no lleva motor y en otro Mac no funcionaría.
 
 ## Firma
 

--- a/docs/superpowers/plans/2026-07-15-registro-ejecucion.md
+++ b/docs/superpowers/plans/2026-07-15-registro-ejecucion.md
@@ -490,9 +490,15 @@ de malware — un falso positivo conocido del *bootloader* autoextraíble de
 PyInstaller. La hipótesis inicial de arreglo (cambiar `--onefile` por `--onedir`)
 era **incorrecta**: el bootloader está en los dos modos.
 
-Consecuencia declarada: la app **no es autocontenida y no se puede distribuir**.
-Invoca `venv-web/bin/python` por ruta absoluta. El indicador de disco no depende
-de Python y sigue funcionando aunque el motor falte.
+La rebanada A se cerró con la app dependiendo de `venv-web/bin/python` por ruta
+absoluta, y por tanto no distribuible. **Eso se resolvió después**, tomando el
+camino que el propio plan dejaba anotado como alternativa:
+[python-build-standalone](https://github.com/astral-sh/python-build-standalone),
+un CPython normal y sin modificar —el que usa `uv`— que al no ser un
+autoextraíble no dispara la heurística. Verificado en la misma máquina que sufrió
+las cuarentenas: pasó sin incidentes. `desktop/tools/preparar-motor.sh` lo
+descarga, lo recorta de 67 a 46 MB y le copia el motor al lado; la `.app` pasa de
+10 a 92 MB y deja de necesitar el repositorio.
 
 **La firma y la notarización siguen pendientes** (decisión D4, sin cuenta de
 Apple). La `.app` va firmada ad hoc. El certificado autofirmado que D4 preveía
@@ -545,10 +551,30 @@ Además, el menú vivo se contrastó contra el motor: mostraba
 6.5 GB del motor Python — la diferencia es la escritura real del disco entre las
 dos lecturas, muy dentro de la tolerancia del 1% del test de consistencia.
 
+### El empaquetado roto que la máquina de desarrollo tapaba
+
+Al conectar el motor empaquetado, la primera versión lo buscaba en
+`Contents/Resources/engine/`. Tauri conserva la ruta relativa declarada en
+`bundle.resources`, así que en realidad queda en
+`Contents/Resources/resources/engine/` — con el prefijo repetido.
+
+El fallo **no se notaba**: la reserva al venv del repositorio entraba en acción y
+la app funcionaba igual. En cualquier Mac sin este repositorio habría dicho
+"Motor de análisis no encontrado". Solo salió mirando qué intérprete corría de
+verdad:
+
+```
+ps -ax -o command | grep disk_analyzer.py
+```
+
+Hay un test que fija la disposición real de Tauri, precisamente porque la reserva
+hace que este fallo sea invisible donde se desarrolla.
+
 ### Lo que queda fuera de esta rebanada
 
 Vigilancia de carpetas, la ventana del panel, Linux y Windows: declarado fuera en
-el spec. `analisis.rs` usa `process_group` y señales POSIX, así que hoy **solo
+el spec. La firma y la notarización siguen pendientes de D4, así que el release
+va **sin firmar y solo para Apple Silicon**. `analisis.rs` usa `process_group` y señales POSIX, así que hoy **solo
 compila en Unix**; portarlo es parte del trabajo de Windows, no una deuda oculta.
 
 ### Deuda menor anotada

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -61,13 +61,15 @@ propios planes.
 
 Dos cosas de la rebanada A que sorprenden si no las sabes:
 
-- **La app no es autocontenida.** Al pulsar "Analizar ahora" ejecuta
-  `venv-web/bin/python` del repositorio por ruta absoluta. Si mueves el
-  repositorio o borras el venv, el análisis deja de funcionar (el menú lo dice);
-  el indicador de disco sigue funcionando porque no depende de Python. El motivo
-  —el antivirus poniendo en cuarentena todo binario de PyInstaller— y los dos
-  caminos abiertos están en el registro de ejecución.
-- **No está firmada ni notarizada.** Va con firma ad hoc, así que Gatekeeper la
+- **Los ~47 MB del motor empaquetado no están en git.** Se regeneran con
+  `./desktop/tools/preparar-motor.sh`, que hay que ejecutar **antes** de
+  compilar. Si te lo saltas, la `.app` se construye igual pero sin motor.
+- **La app cae al venv del repositorio si no encuentra motor empaquetado.** Es
+  cómodo para desarrollar y traicionero para verificar: un empaquetado roto
+  funciona igual en la máquina donde se compiló. Para saber qué motor usa de
+  verdad, lanza un análisis y mira
+  `ps -ax -o command | grep disk_analyzer.py`.
+- **No está firmada ni notarizada, y es solo para Apple Silicon.** Gatekeeper la
   bloquea con doble clic: ábrela con clic derecho → Abrir. Y como el hash cambia
   en cada compilación, el permiso de Acceso a disco completo se rompe en cada
   build. El runbook explica cómo arreglarlo con un certificado autofirmado.


### PR DESCRIPTION
La rebanada A se cerró con una app que funcionaba, pero **solo en la máquina que la compiló**: invocaba `venv-web/bin/python` por ruta absoluta. Este PR la vuelve autocontenida y por tanto distribuible.

## Cómo

Empaquetando dentro de la `.app` su propio CPython y una copia del motor. La `.app` pasa de 10 a 92 MB y deja de necesitar este repositorio, `venv-web` o un Python del sistema.

El camino es el que **el propio plan ya dejaba anotado** como alternativa a PyInstaller: [python-build-standalone](https://github.com/astral-sh/python-build-standalone), un CPython normal y sin modificar —el mismo que usa `uv`—. Al no ser un autoextraíble no dispara la heurística que puso en cuarentena los tres binarios de PyInstaller. Verificado en la misma máquina que sufrió las cuarentenas: pasó sin incidentes.

Los ~47 MB del motor **no van a git**. `desktop/tools/preparar-motor.sh` los regenera: descarga el intérprete, lo recorta de 67 a 46 MB (Tcl/Tk, tests, pip) y le copia el motor al lado.

## El empaquetado roto que la máquina de desarrollo tapaba

La primera versión buscaba el motor en `Contents/Resources/engine/`. Tauri conserva la ruta relativa declarada en `bundle.resources`, así que en realidad queda en `Contents/Resources/resources/engine/`, con el prefijo repetido.

**El fallo no se notaba.** La reserva al venv del repositorio entraba en acción y la app funcionaba igual; en cualquier Mac sin este repositorio habría dicho "Motor de análisis no encontrado". Solo salió mirando qué intérprete corría de verdad:

```
ps -ax -o command | grep disk_analyzer.py
```

Hay un test que fija la disposición real de Tauri precisamente por eso: la reserva vuelve este fallo invisible justo donde se desarrolla.

## Verificación

- `make test`: **233 en verde** (151 backend + 69 frontend + 13 Rust).
- Sobre la `.app` instalada en `/Applications`: se lanzó un análisis y se confirmó por `ps` que **tanto el intérprete como el script salen de dentro del bundle**, sin tocar el repositorio.
- Cancelación de punta a punta: el escaneo murió y el menú quedó en "Análisis cancelado" — el estado correcto, que es justo lo que protege el arreglo de la carrera del PR anterior.

## Lo que sigue pendiente

Sin firmar ni notarizar, y solo para Apple Silicon. La notarización depende de la decisión D4 (cuenta de desarrollador de Apple), que sigue pospuesta. Gatekeeper bloquea el doble clic: hay que abrirla la primera vez con clic derecho → Abrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)