### PR TITLE
fix: firmar el bundle ad hoc y empaquetar el release con un script

### DIFF
--- a/desktop/tools/empaquetar-release.sh
+++ b/desktop/tools/empaquetar-release.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Construye el artefacto distribuible de la app de bandeja, de principio a fin.
+#
+#   ./desktop/tools/empaquetar-release.sh [version]
+#
+# Deja un .zip listo para subir en `desktop/dist/`.
+set -euo pipefail
+
+VERSION="${1:-v0.1.0}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+ARCH="$(uname -m)"
+APP="desktop/src-tauri/target/release/bundle/macos/Disk Use Analyzer.app"
+DESTINO="desktop/dist"
+ZIP="$DESTINO/DiskUseAnalyzer-${VERSION}-macos-${ARCH}.zip"
+
+# rustup instala cargo en ~/.cargo/bin, que no está en el PATH de un shell no
+# interactivo. Sin esto, `tauri build` falla con un críptico "failed to run
+# 'cargo metadata'".
+if ! command -v cargo >/dev/null 2>&1; then
+  export PATH="$HOME/.cargo/bin:$PATH"
+fi
+command -v cargo >/dev/null 2>&1 || { echo "No encuentro cargo. Instálalo: https://rustup.rs" >&2; exit 1; }
+
+echo "▸ 1/4 Preparando el motor autocontenido"
+./desktop/tools/preparar-motor.sh
+
+echo "▸ 2/4 Compilando la .app"
+(cd desktop && npm run tauri build -- --bundles app)
+
+# Tauri deja el ejecutable con la firma del enlazador, pero NO firma el bundle:
+# queda sin `_CodeSignature` y con "Sealed Resources=none", y `codesign
+# --verify` lo rechaza con "code has no resources but signature indicates they
+# must be present". macOS puede llegar a matar una app en ese estado por
+# considerarla dañada, así que se firma ad hoc aquí.
+#
+# De dentro hacia fuera, no con `--deep`: `--deep` firma lo anidado con las
+# mismas opciones que el contenedor, que casi nunca es lo que quieres, y Apple
+# lo desaconseja para firmar (solo para verificar).
+echo "▸ 3/4 Firmando ad hoc, de dentro hacia fuera"
+find "$APP/Contents/Resources" -type f \
+  \( -name "*.so" -o -name "*.dylib" -o -perm -u+x \) 2>/dev/null \
+  | while read -r f; do
+      if file -b "$f" | grep -q "Mach-O"; then
+        codesign --force --timestamp=none -s - "$f" 2>/dev/null || true
+      fi
+    done
+codesign --force --timestamp=none -s - "$APP"
+codesign --verify --deep --strict "$APP"
+echo "  ✓ firma ad hoc válida"
+
+echo "▸ 4/4 Comprimiendo"
+mkdir -p "$DESTINO"
+rm -f "$ZIP"
+# `ditto`, no `zip`: conserva los metadatos y permisos de macOS, sin los cuales
+# la .app llega rota al otro lado.
+ditto -c -k --keepParent --sequesterRsrc "$APP" "$ZIP"
+
+echo
+echo "▸ Listo: $ZIP ($(du -h "$ZIP" | cut -f1))"
+echo "  Sin firmar con Developer ID y sin notarizar: Gatekeeper bloqueará el"
+echo "  doble clic. Se abre con clic derecho → Abrir."

--- a/docs/runbooks/app-bandeja.md
+++ b/docs/runbooks/app-bandeja.md
@@ -21,6 +21,26 @@ desarrollador de Apple). Gatekeeper la bloquea con doble clic; hay que abrirla l
 primera vez con clic derecho → **Abrir**. Y es **solo para Apple Silicon**
 (`arm64`); no hay build para Intel.
 
+### Construir el artefacto distribuible
+
+Un solo comando hace las cuatro cosas —preparar el motor, compilar, firmar y
+comprimir— y deja el `.zip` en `desktop/dist/`:
+
+```bash
+./desktop/tools/empaquetar-release.sh v0.1.0
+```
+
+**La firma ad hoc no es opcional.** Tauri deja el ejecutable con la firma del
+enlazador pero **no firma el bundle**: queda sin `_CodeSignature`, con
+`Sealed Resources=none`, y `codesign --verify` lo rechaza con *"code has no
+resources but signature indicates they must be present"*. macOS puede matar una
+app en ese estado por considerarla dañada. El script la firma ad hoc de dentro
+hacia fuera, y deja `Identifier=dev.diskanalyzer.app` en vez del
+`desktop-<hash>` que ponía el enlazador.
+
+Se comprime con `ditto`, no con `zip`: `zip` a secas pierde metadatos y permisos
+de macOS y la `.app` llega rota al otro lado.
+
 ### Regenerar el motor empaquetado
 
 Los ~47 MB del motor **no están en git**: se regeneran. Antes de compilar:


### PR DESCRIPTION
Preparando el primer artefacto distribuible salió que **Tauri no firma el bundle**. Deja el ejecutable con la firma del enlazador, pero la `.app` queda sin `_CodeSignature` y con `Sealed Resources=none`, así que `codesign --verify` la rechaza:

```
code has no resources but signature indicates they must be present
```

macOS puede matar una app en ese estado por considerarla dañada.

`desktop/tools/empaquetar-release.sh` hace las cuatro cosas en orden: prepara el motor, compila, firma ad hoc y comprime. Deja el `.zip` en `desktop/dist/`.

## Tres detalles, una vuelta cada uno

- **Firma de dentro hacia fuera, no `--deep`.** `--deep` firma lo anidado con las mismas opciones que el contenedor, y Apple lo desaconseja para firmar (solo para verificar). Tras firmar bien, el identificador pasa de `desktop-<hash>` a `dev.diskanalyzer.app`.
- **`ditto` y no `zip`.** `zip` a secas pierde metadatos y permisos de macOS: la `.app` llega rota al otro lado.
- **El script exporta `~/.cargo/bin` al PATH.** rustup instala cargo ahí, fuera del PATH de un shell no interactivo, y sin eso `tauri build` falla con un críptico *"failed to run 'cargo metadata'"*.

## Verificación

Descomprimiendo el artefacto en otra ruta, como haría quien se lo descarga:

- La firma **sobrevive** al viaje por el zip (`codesign --verify --deep --strict` pasa).
- La app arranca desde esa ruta arbitraria.
- El análisis usa el intérprete **de dentro de su propio bundle**, confirmado por `ps`.
- Gatekeeper la **rechaza**, que es lo esperado y documentado: sin Developer ID hay que abrirla con clic derecho → Abrir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)