### PR TITLE
test: quitar la carrera de test_list_sessions

### DIFF
--- a/tests/test_pty_manager.py
+++ b/tests/test_pty_manager.py
@@ -60,7 +60,11 @@ class TestPTYManager:
 
     def test_list_sessions(self):
         id1 = self.manager.create_session()
-        id2 = self.manager.create_session(command="echo hi")
+        # A long-lived command, not `echo hi`. `list_sessions` prunes dead
+        # sessions via `_pop_dead`, and `echo hi` exits immediately, so the
+        # test was a race between the child exiting and the listing. It
+        # passed locally and failed on CI, where the child won more often.
+        id2 = self.manager.create_session(command="sleep 30")
         sessions = self.manager.list_sessions()
         assert len(sessions) == 2
         ids = [s['pty_id'] for s in sessions]


### PR DESCRIPTION
El test creaba una sesión PTY con `echo hi`, que termina de inmediato, y acto seguido pedía el listado. `list_sessions` poda las sesiones muertas con `_pop_dead`, así que era una **carrera** entre el hijo saliendo y el listado leyéndose. Ahora usa un comando de vida larga.

Falló en el CI —1 sesión donde esperaba 2, y la superviviente era la del comando `None`— pero **no en local**: 15 corridas seguidas aquí pasan las 15, también con `echo hi`. La justificación es el log del CI más la lectura de `_pop_dead`, no una reproducción local.

Es un fallo preexistente, ajeno al trabajo de la app de bandeja. Salió en el CI del #16, que solo tocaba un script de shell — y **ese PR se mergeó con el check en rojo, que no debió pasar**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)