### PR TITLE
fix: distinguir "pide sudo" de "falta Acceso total al disco"

### DIFF
--- a/desktop/src-tauri/src/analisis.rs
+++ b/desktop/src-tauri/src/analisis.rs
@@ -55,8 +55,30 @@ pub enum Resultado {
     /// `PermissionError` per-directory and keeps going), so silence here
     /// would mean the very first thing a new user hits goes unexplained.
     SinPermisos,
+    /// El informe salió entero salvo unas pocas carpetas que ni con Acceso
+    /// total al disco se pueden leer: son de `root` con permisos 700 y solo
+    /// se abren con `sudo`. No es un fallo, y decir lo contrario mandaba al
+    /// usuario a activar un permiso que ya tenía.
+    Parcial(usize),
     Cancelado,
     Fallo(String),
+}
+
+/// Si esta app tiene concedido el Acceso total al disco.
+///
+/// Sonda directa en vez de deducirlo de los errores del informe: esa carpeta
+/// solo se puede listar con el permiso concedido. Deducirlo era el error
+/// original — un escaneo del disco entero **siempre** topa con unas pocas
+/// carpetas de `root` (`/usr/sbin/authserver`, cachés de Apple, algún
+/// antivirus), así que tomar cualquier error de permisos como "falta el
+/// Acceso total al disco" daba un falso positivo permanente. Medido en la
+/// máquina de desarrollo, con el permiso ya concedido: 10 errores, ninguno
+/// de ellos de una ruta protegida por TCC.
+pub fn hay_acceso_total_al_disco() -> bool {
+    let Some(home) = std::env::var_os("HOME") else {
+        return false;
+    };
+    std::fs::read_dir(Path::new(&home).join("Library/Application Support/com.apple.TCC")).is_ok()
 }
 
 impl Resultado {
@@ -69,6 +91,9 @@ impl Resultado {
                  Seguridad > Acceso total al disco y activa esta app"
                     .to_string()
             }
+            Resultado::Parcial(n) => format!(
+                "Último análisis: completado ({n} carpetas de sistema omitidas, piden sudo)"
+            ),
             Resultado::Cancelado => "Análisis cancelado".to_string(),
             Resultado::Fallo(msg) => format!("Error al analizar: {msg}"),
         }
@@ -245,7 +270,9 @@ impl AnalisisManager {
                 Resultado::Cancelado
             } else {
                 match status {
-                    Ok(status) if status.success() => evaluar_export(&export_path),
+                    Ok(status) if status.success() => {
+                        evaluar_export(&export_path, hay_acceso_total_al_disco())
+                    }
                     Ok(status) => Resultado::Fallo(leer_stderr_o_codigo(&stderr_path, status)),
                     Err(e) => Resultado::Fallo(format!("no se pudo esperar al proceso: {e}")),
                 }
@@ -419,7 +446,7 @@ fn comando_analisis(motor: &Motor) -> Result<Comando, String> {
 /// scan without Full Disk Access still exits 0 and produces a report; the
 /// only way to notice is to look at `errors` after the fact, which is
 /// exactly what this does.
-fn evaluar_export(export_path: &Path) -> Resultado {
+fn evaluar_export(export_path: &Path, hay_acceso_total: bool) -> Resultado {
     let contents = match std::fs::read_to_string(export_path) {
         Ok(c) => c,
         Err(e) => return Resultado::Fallo(format!("no se generó el reporte: {e}")),
@@ -428,22 +455,28 @@ fn evaluar_export(export_path: &Path) -> Resultado {
         Ok(v) => v,
         Err(e) => return Resultado::Fallo(format!("reporte ilegible: {e}")),
     };
-    let sin_permisos = json
+    let errores_de_permisos = json
         .get("errors")
         .and_then(|e| e.as_array())
         .map(|errores| {
-            errores.iter().any(|e| {
-                e.as_str()
-                    .map(|s| s.to_lowercase().contains("permisos"))
-                    .unwrap_or(false)
-            })
+            errores
+                .iter()
+                .filter(|e| {
+                    e.as_str()
+                        .map(|s| s.to_lowercase().contains("permiso"))
+                        .unwrap_or(false)
+                })
+                .count()
         })
-        .unwrap_or(false);
+        .unwrap_or(0);
 
-    if sin_permisos {
-        Resultado::SinPermisos
-    } else {
-        Resultado::Exito
+    match (errores_de_permisos, hay_acceso_total) {
+        (0, _) => Resultado::Exito,
+        // Sin el permiso concedido, los errores son la señal de que hay que
+        // concederlo: es el primer arranque de cualquier usuario nuevo.
+        (_, false) => Resultado::SinPermisos,
+        // Con el permiso ya concedido, lo que queda son carpetas de root.
+        (n, true) => Resultado::Parcial(n),
     }
 }
 
@@ -680,7 +713,7 @@ mod tests {
             r#"{"errors": ["Sin permisos: /Library/Application Support"]}"#,
         )
         .unwrap();
-        let resultado = evaluar_export(&ruta);
+        let resultado = evaluar_export(&ruta, false);
         let _ = std::fs::remove_file(&ruta);
 
         assert!(matches!(resultado, Resultado::SinPermisos));
@@ -726,11 +759,39 @@ mod tests {
         );
     }
 
+    /// Con el permiso ya concedido, unas pocas carpetas de `root` no son un
+    /// fallo del permiso. Mandar al usuario a activar lo que ya tiene
+    /// activado fue el bug real: un escaneo del disco entero siempre topa
+    /// con ellas, así que el aviso salía siempre.
+    #[test]
+    fn con_acceso_concedido_las_carpetas_de_root_no_piden_el_permiso() {
+        let ruta = ruta_temporal("json");
+        std::fs::write(
+            &ruta,
+            r#"{"errors": ["Sin permisos para leer: /usr/sbin/authserver",
+                           "Sin permisos para leer: /Library/Application Support/Avast/config/chest-data"]}"#,
+        )
+        .unwrap();
+        let resultado = evaluar_export(&ruta, true);
+        let _ = std::fs::remove_file(&ruta);
+
+        match resultado {
+            Resultado::Parcial(2) => {}
+            otro => panic!("esperaba Parcial(2), salió {otro:?}"),
+        }
+        let resumen = resultado.resumen();
+        assert!(
+            !resumen.contains("Acceso total al disco"),
+            "sigue pidiendo un permiso ya concedido: {resumen}"
+        );
+        assert!(resumen.contains("sudo"), "no dice cuál es el remedio real");
+    }
+
     #[test]
     fn un_export_limpio_es_exito() {
         let ruta = ruta_temporal("json");
         std::fs::write(&ruta, r#"{"errors": [], "total_size": 123}"#).unwrap();
-        let resultado = evaluar_export(&ruta);
+        let resultado = evaluar_export(&ruta, true);
         let _ = std::fs::remove_file(&ruta);
         assert!(matches!(resultado, Resultado::Exito));
     }
@@ -740,13 +801,13 @@ mod tests {
         // Silence here would be the worst outcome: the menu would claim the
         // scan completed while no report was ever written.
         assert!(matches!(
-            evaluar_export(Path::new("/no/existe/reporte.json")),
+            evaluar_export(Path::new("/no/existe/reporte.json"), true),
             Resultado::Fallo(_)
         ));
 
         let ruta = ruta_temporal("json");
         std::fs::write(&ruta, "esto no es json").unwrap();
-        let resultado = evaluar_export(&ruta);
+        let resultado = evaluar_export(&ruta, true);
         let _ = std::fs::remove_file(&ruta);
         assert!(matches!(resultado, Resultado::Fallo(_)));
     }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -143,8 +143,15 @@ pub fn run() {
             // opción está apagada.
             if !hay_motor {
                 let _ = analizar_item.set_enabled(false);
-                let _ = estado_analisis_item
-                    .set_text("Motor de análisis no encontrado");
+                let _ = estado_analisis_item.set_text("Motor de análisis no encontrado");
+            } else if !analisis::hay_acceso_total_al_disco() {
+                // Decirlo al arrancar y no al terminar: el escaneo del disco
+                // completo tarda un par de minutos, y hacer esperar todo eso
+                // para anunciar un permiso que falta desde el principio es
+                // gratuito.
+                let _ = estado_analisis_item.set_text(
+                    "Sin acceso total al disco: el análisis saldrá incompleto",
+                );
             }
 
             let mut tray_builder = TrayIconBuilder::new().menu(&menu).show_menu_on_left_click(true);

--- a/docs/runbooks/app-bandeja.md
+++ b/docs/runbooks/app-bandeja.md
@@ -152,9 +152,18 @@ elige la `.app`. Después **cierra y vuelve a abrir la app**: macOS no reevalúa
 el permiso de un proceso ya en marcha.
 
 Sin este permiso el análisis **no falla**: el motor se salta los directorios
-protegidos y termina con éxito, con un informe incompleto. Por eso el menú
-detecta los errores de permisos en el informe y lo dice explícitamente en vez de
-callarse.
+protegidos y termina con éxito, con un informe incompleto. La app lo detecta
+sondeando directamente si puede listar
+`~/Library/Application Support/com.apple.TCC`, y lo dice en el menú **al
+arrancar**, sin hacerte esperar a un escaneo que tarda minutos.
+
+**No confundas esto con los directorios que piden `sudo`.** Un escaneo del disco
+entero siempre topa con un puñado de carpetas de `root` en modo 700
+—`/usr/sbin/authserver`, cachés de Apple, algún antivirus— que no se leen ni con
+Acceso total al disco. Medido en la máquina de desarrollo con el permiso
+concedido: 10 carpetas así, ninguna protegida por TCC. La app las reporta aparte,
+como "N carpetas de sistema omitidas, piden sudo", en vez de mandarte a activar
+un permiso que ya tienes.
 
 ### Revocarlo, y la trampa de la entrada huérfana
 


### PR DESCRIPTION
El menú avisaba de que faltaba el Acceso total al disco **aunque estuviera concedido**.

Deducía el permiso de los errores del informe, y un escaneo del disco entero *siempre* topa con carpetas de `root` en modo 700 —`/usr/sbin/authserver`, cachés de Apple, el cofre de Avast—. El aviso salía siempre, y mandaba al usuario a activar algo que ya tenía activado.

## Cómo se midió

Capturando con un enlace duro el informe real que produce la app, antes de que ella misma lo borre. Con el permiso concedido: **10 errores de permisos, ninguno de una ruta protegida por TCC**.

## El arreglo

Sonda directa: ¿puede listar `~/Library/Application Support/com.apple.TCC`? Esa carpeta es **del usuario** y está en modo `700`, así que por permisos Unix debería poder leerla — si no puede, la denegación solo puede venir de TCC. Verificado en los dos sentidos: un proceso sin el permiso es rechazado, y el escaneo que sí lo tenía leyó `~/Library/Safari` y `~/Library/Mail` sin un solo error.

Con el permiso concedido, esas carpetas pasan a reportarse como *"N carpetas de sistema omitidas, piden sudo"*, que es el remedio real. Y el aviso de permiso ausente sale **al arrancar**, no tras esperar minutos a un escaneo.

## Verificación

`cargo test`: **16 en verde**, clippy limpio con `-D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)