### PR TITLE
feat: "Abrir analizador completo" arranca el servidor de verdad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,16 @@ The project has three interfaces: CLI, GUI, and Web.
 - **Build:** `cd desktop && npm run tauri build -- --bundles app`
 - **Tests:** `cargo test --manifest-path desktop/src-tauri/Cargo.toml` (also run by `make test`)
 - **Bundled engine:** the `.app` ships its own trimmed CPython
-  (python-build-standalone) plus a copy of the engine, so it needs neither this
-  repo nor a system Python. Those ~47 MB are **not in git** — run
+  (python-build-standalone), a copy of the analysis engine, and the whole web
+  server (FastAPI/uvicorn plus the built Astro frontend), so it needs neither
+  this repo nor a system Python. Those ~77 MB are **not in git** — run
   `./desktop/tools/preparar-motor.sh` before `npm run tauri build`, or the
   `.app` builds without an engine.
+- **"Abrir analizador completo" starts that bundled server** and opens the
+  browser on it, passing `--host 127.0.0.1`: the web UI includes a terminal
+  running with the user's privileges, so a menu click must not publish it to
+  the LAN. `disk_analyzer_web.py` still defaults to `0.0.0.0` — that is the
+  documented `make web` behaviour and tests pin both halves.
 - **Two things that will surprise you:** the app falls back to
   `venv-web/bin/python` when no bundled engine is found, which means a broken
   packaging looks fine on a dev machine — check with

--- a/desktop/src-tauri/src/analisis.rs
+++ b/desktop/src-tauri/src/analisis.rs
@@ -81,6 +81,17 @@ pub fn hay_acceso_total_al_disco() -> bool {
     std::fs::read_dir(Path::new(&home).join("Library/Application Support/com.apple.TCC")).is_ok()
 }
 
+impl Motor {
+    pub fn python(&self) -> &Path {
+        &self.python
+    }
+    /// Directorio desde el que se lanza el motor. Es también donde viven sus
+    /// módulos y sus dependencias, así que Python los encuentra solo.
+    pub fn cwd(&self) -> &Path {
+        &self.cwd
+    }
+}
+
 impl Resultado {
     /// Spanish, user-facing summary for the "estado_analisis" menu line.
     pub fn resumen(&self) -> String {

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -9,16 +9,16 @@ use tauri::Manager;
 pub mod analisis;
 pub mod disk;
 pub mod estado;
+pub mod servidor;
 
 use analisis::AnalisisManager;
+use servidor::Servidor;
 use disk::DiskUsage;
 use estado::Estado;
 
 /// Disk usage costs 0.7 µs to read (measured) -- 5s is plenty responsive
 /// without needing any justification for the cost.
 const POLL_INTERVAL: Duration = Duration::from_secs(5);
-
-const URL_ANALIZADOR_COMPLETO: &str = "http://localhost:8000/";
 
 fn gb(bytes: u64) -> f64 {
     bytes as f64 / (1024.0 * 1024.0 * 1024.0)
@@ -130,12 +130,14 @@ pub fn run() {
 
             let motor = analisis::localizar_motor(app.path().resource_dir().ok());
             let hay_motor = motor.is_some();
-            let manager = Arc::new(AnalisisManager::new(motor));
+            let manager = Arc::new(AnalisisManager::new(motor.clone()));
+            let servidor = Arc::new(Servidor::new());
             // Managed state so the shutdown handler in `run()` below (which
             // runs outside `setup` and has no closure access to `manager`)
             // can still reach it to guarantee cleanup on any exit path, not
             // just the "quit" menu item.
             app.manage(Arc::clone(&manager));
+            app.manage(Arc::clone(&servidor));
 
             // Decirlo desde el arranque, no solo al pulsar: sin motor, el
             // indicador de disco sigue siendo perfectamente útil, así que la
@@ -168,11 +170,17 @@ pub fn run() {
 
             let tray = {
                 let manager = Arc::clone(&manager);
+                let servidor = Arc::clone(&servidor);
+                let motor_web = motor.clone();
+                let abrir_item = abrir_item.clone();
                 let analizar_item = analizar_item.clone();
                 let estado_analisis_item = estado_analisis_item.clone();
                 tray_builder
                     .on_menu_event(move |app, event| {
                         if event.id() == "quit" {
+                            // El servidor web también: lo arrancamos nosotros,
+                            // así que no debe sobrevivirnos ocupando el 8000.
+                            servidor.kill_blocking();
                             // Block briefly (bounded by KILL_REAP_TIMEOUT)
                             // so the scan's process group is confirmed dead
                             // before the app actually tears down -- "no
@@ -181,10 +189,24 @@ pub fn run() {
                             manager.kill_blocking();
                             app.exit(0);
                         } else if event.id() == "abrir" {
-                            let _ = tauri_plugin_opener::open_url(
-                                URL_ANALIZADOR_COMPLETO,
-                                None::<&str>,
-                            );
+                            // Arrancar FastAPI lleva varios segundos, así que
+                            // el ítem lo dice en vez de parecer que el clic no
+                            // hizo nada.
+                            let volver = abrir_item.clone();
+                            let _ = abrir_item.set_text("Arrancando el analizador…");
+                            let _ = abrir_item.set_enabled(false);
+                            servidor.abrir(motor_web.as_ref(), move |resultado| {
+                                let _ = volver.set_enabled(true);
+                                match resultado {
+                                    Ok(url) => {
+                                        let _ = volver.set_text("Abrir analizador completo");
+                                        let _ = tauri_plugin_opener::open_url(url, None::<&str>);
+                                    }
+                                    Err(e) => {
+                                        let _ = volver.set_text(format!("No se pudo abrir: {e}"));
+                                    }
+                                }
+                            });
                         } else if event.id() == "analizar" {
                             if manager.is_running() {
                                 if manager.cancel() {
@@ -261,6 +283,9 @@ pub fn run() {
             if let tauri::RunEvent::ExitRequested { .. } = event {
                 if let Some(manager) = app_handle.try_state::<Arc<AnalisisManager>>() {
                     manager.kill_blocking();
+                }
+                if let Some(servidor) = app_handle.try_state::<Arc<Servidor>>() {
+                    servidor.kill_blocking();
                 }
             }
         });

--- a/desktop/src-tauri/src/servidor.rs
+++ b/desktop/src-tauri/src/servidor.rs
@@ -1,0 +1,209 @@
+//! Arranca el servidor web del propio proyecto, bajo demanda, desde el ítem
+//! "Abrir analizador completo".
+//!
+//! Antes ese ítem se limitaba a abrir `http://localhost:8000/`, dando por
+//! hecho que el servidor ya estaba corriendo. En la app empaquetada no podía
+//! estarlo nunca: el bundle no llevaba el servidor. El resultado era un botón
+//! que abría una pestaña con un error de conexión.
+//!
+//! Dos decisiones que no son obvias:
+//!
+//! - **Se ata a loopback, no a toda la red.** El servidor por defecto escucha
+//!   en `0.0.0.0` porque el acceso desde otros dispositivos es una función
+//!   documentada de `make web`. Pero aquí lo arranca un clic de menú, y la
+//!   interfaz web incluye una terminal que corre con los privilegios del
+//!   usuario: publicarla en la red sin que nadie lo haya pedido sería una
+//!   sorpresa desagradable. Por eso se le pasa `--host 127.0.0.1`.
+//! - **El token viaja por variable de entorno.** El servidor corre con
+//!   `reload=True`, así que uvicorn reimporta el módulo en un subproceso y
+//!   cualquier cosa definida solo en el bloque `__main__` no llega al worker
+//!   que atiende las peticiones. `DISK_ANALYZER_TOKEN` sí llega.
+
+use std::io::Read;
+use std::net::{Shutdown, SocketAddr, TcpStream};
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::analisis::Motor;
+
+const PUERTO: u16 = 8000;
+const HOST: &str = "127.0.0.1";
+/// Cuánto se espera a que el servidor acepte conexiones. Arrancar FastAPI y
+/// uvicorn lleva varios segundos en frío; medido en esta máquina, entre 8 y
+/// 10. El margen es generoso a propósito: quedarse corto se manifiesta como
+/// "el botón no hace nada".
+const ARRANQUE_MAXIMO: Duration = Duration::from_secs(45);
+const SONDEO: Duration = Duration::from_millis(250);
+const TERM_GRACE: Duration = Duration::from_millis(300);
+
+fn direccion() -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], PUERTO))
+}
+
+/// Si algo acepta conexiones en el puerto. No distingue *qué* escucha: eso lo
+/// resuelve `Servidor`, que sabe si la instancia es suya.
+fn puerto_ocupado() -> bool {
+    match TcpStream::connect_timeout(&direccion(), Duration::from_millis(400)) {
+        Ok(s) => {
+            let _ = s.shutdown(Shutdown::Both);
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Token de un solo uso para esta instancia del servidor.
+///
+/// Se lee de `/dev/urandom` en vez de tirar de una dependencia nueva: son 16
+/// bytes y el proyecto no tiene ningún otro motivo para arrastrar un
+/// generador criptográfico.
+fn token_nuevo() -> Result<String, String> {
+    let mut bytes = [0u8; 16];
+    std::fs::File::open("/dev/urandom")
+        .and_then(|mut f| f.read_exact(&mut bytes))
+        .map_err(|e| format!("no se pudo generar el token: {e}"))?;
+    Ok(bytes.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+struct Instancia {
+    pid: i32,
+    url: String,
+}
+
+pub struct Servidor {
+    instancia: Mutex<Option<Instancia>>,
+}
+
+impl Servidor {
+    pub fn new() -> Self {
+        Self {
+            instancia: Mutex::new(None),
+        }
+    }
+
+    /// Deja listo el analizador web y entrega por `al_terminar` la URL que hay
+    /// que abrir.
+    ///
+    /// No bloquea: arrancar el servidor lleva segundos y esto lo llama el hilo
+    /// que atiende el menú. La espera ocurre en un hilo aparte.
+    pub fn abrir<F>(self: &Arc<Self>, motor: Option<&Motor>, al_terminar: F)
+    where
+        F: FnOnce(Result<String, String>) + Send + 'static,
+    {
+        // Ya teníamos uno vivo: se reutiliza con su token, en vez de arrancar
+        // un segundo que chocaría en el mismo puerto.
+        {
+            let guard = self.instancia.lock().unwrap();
+            if let Some(inst) = guard.as_ref() {
+                if puerto_ocupado() {
+                    al_terminar(Ok(inst.url.clone()));
+                    return;
+                }
+            }
+        }
+
+        // El puerto está ocupado por algo que no es nuestro: puede ser un
+        // `make web` del propio usuario. No conocemos su token, así que se
+        // abre la URL a secas y que la sesión del navegador haga el resto.
+        if puerto_ocupado() {
+            al_terminar(Ok(format!("http://{HOST}:{PUERTO}/")));
+            return;
+        }
+
+        // Sin motor empaquetado no hay servidor que arrancar. No es
+        // necesariamente un error: puede haber un `make web` del usuario que
+        // ya se habría atendido arriba.
+        let Some(motor) = motor else {
+            al_terminar(Err(
+                "no hay servidor que abrir: falta el motor empaquetado".to_string()
+            ));
+            return;
+        };
+
+        let token = match token_nuevo() {
+            Ok(t) => t,
+            Err(e) => {
+                al_terminar(Err(e));
+                return;
+            }
+        };
+        let script = motor.cwd().join("disk_analyzer_web.py");
+        if !script.is_file() {
+            al_terminar(Err("el motor empaquetado no trae el servidor web".to_string()));
+            return;
+        }
+
+        let mut cmd = Command::new(motor.python());
+        cmd.current_dir(motor.cwd())
+            .arg(&script)
+            .arg("--host")
+            .arg(HOST)
+            .arg("--port")
+            .arg(PUERTO.to_string())
+            .env("DISK_ANALYZER_TOKEN", &token)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            // Grupo propio: uvicorn con recarga levanta un worker aparte, así
+            // que matar solo al proceso que lanzamos dejaría ese worker vivo
+            // ocupando el puerto.
+            .process_group(0);
+
+        let child = match cmd.spawn() {
+            Ok(c) => c,
+            Err(e) => {
+                al_terminar(Err(format!("no se pudo arrancar el servidor: {e}")));
+                return;
+            }
+        };
+        let pid = child.id() as i32;
+        let url = format!("http://{HOST}:{PUERTO}/?token={token}");
+        *self.instancia.lock().unwrap() = Some(Instancia {
+            pid,
+            url: url.clone(),
+        });
+
+        let servidor = Arc::clone(self);
+        std::thread::spawn(move || {
+            let limite = Instant::now() + ARRANQUE_MAXIMO;
+            while Instant::now() < limite {
+                if puerto_ocupado() {
+                    al_terminar(Ok(url));
+                    return;
+                }
+                std::thread::sleep(SONDEO);
+            }
+            // No llegó a escuchar: se recoge para no dejar un proceso a medias.
+            servidor.matar(pid);
+            *servidor.instancia.lock().unwrap() = None;
+            al_terminar(Err("el servidor no llegó a arrancar".to_string()));
+        });
+    }
+
+    fn matar(&self, pid: i32) {
+        unsafe {
+            libc::kill(-pid, libc::SIGTERM);
+        }
+        std::thread::sleep(TERM_GRACE);
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+
+    /// Al salir de la app. Igual que con el análisis: lo que arrancamos
+    /// nosotros no debe sobrevivirnos ocupando el puerto 8000.
+    pub fn kill_blocking(&self) {
+        let inst = self.instancia.lock().unwrap().take();
+        if let Some(inst) = inst {
+            self.matar(inst.pid);
+        }
+    }
+}
+
+impl Default for Servidor {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/desktop/tools/preparar-motor.sh
+++ b/desktop/tools/preparar-motor.sh
@@ -68,7 +68,29 @@ echo "▸ Copiando el motor…"
 cd "$REPO_ROOT"
 cp disk_analyzer.py disk_analyzer_core.py "$DESTINO/"
 cp -R analyzer "$DESTINO/analyzer"
-find "$DESTINO/analyzer" -name "__pycache__" -type d -prune -exec rm -rf {} + 2>/dev/null || true
+
+# El servidor web, para que "Abrir analizador completo" funcione sin depender
+# de este repositorio. `disk_analyzer_web.py` resuelve sus rutas con
+# `Path(__file__).parent`, así que `web/dist` y `static/` tienen que quedar
+# exactamente donde están aquí, relativos a él.
+echo "▸ Copiando el servidor web…"
+if [ ! -d web/dist ]; then
+  echo "  El frontend no está construido. Construyéndolo…"
+  (cd web && npm run build >/dev/null)
+fi
+cp disk_analyzer_web.py pty_manager.py agents_manager.py persona_detector.py "$DESTINO/"
+mkdir -p "$DESTINO/web"
+cp -R web/dist "$DESTINO/web/dist"
+cp -R static "$DESTINO/static"
+
+# Las dependencias del servidor, instaladas al lado del código. Se usa el pip
+# del venv del repositorio porque el intérprete empaquetado viene sin pip (lo
+# quita el recorte de arriba); las ruedas valen igual, porque son de la misma
+# versión de Python y la misma arquitectura.
+echo "▸ Instalando las dependencias del servidor (~25 MB)…"
+venv-web/bin/pip install -q --target "$DESTINO" -r requirements-web.txt
+
+find "$DESTINO" -name "__pycache__" -type d -prune -exec rm -rf {} + 2>/dev/null || true
 
 echo "▸ Comprobando que arranca…"
 "$DESTINO/python/bin/python3" -c "
@@ -77,5 +99,7 @@ from disk_analyzer_core import DiskAnalyzerCore
 d = DiskAnalyzerCore('.').get_disk_usage()
 assert d['total'] > 0
 print('  ✓ motor operativo:', round(d['total']/1024**3, 1), 'GB totales')
+import fastapi, uvicorn  # noqa: F401
+print('  ✓ servidor web importable')
 "
 echo "▸ Listo: $DESTINO ($(du -sh "$DESTINO" | cut -f1))"

--- a/disk_analyzer_web.py
+++ b/disk_analyzer_web.py
@@ -1418,6 +1418,15 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=8000, help="Server port (default: 8000)")
     parser.add_argument("--no-auth", action="store_true",
                         help="Disable token auth (only on a fully trusted, isolated network)")
+    # The default stays 0.0.0.0 so `make web` keeps working from other devices
+    # on the LAN, which is a documented feature. The menu-bar app passes
+    # 127.0.0.1 instead: it starts this server on a single click, and the web
+    # UI includes a terminal running with the user's privileges, so exposing
+    # it to the whole network without the user ever asking would be a nasty
+    # surprise.
+    parser.add_argument("--host", default="0.0.0.0",
+                        help="Interface to bind (default: 0.0.0.0, the whole LAN; "
+                             "use 127.0.0.1 to keep it on this machine only)")
     args = parser.parse_args()
 
     app.state.default_min_size_mb = args.min_size
@@ -1446,14 +1455,16 @@ if __name__ == "__main__":
         suffix = f"/?token={token}"
     print(f"\n📍 Accede a la interfaz web en:")
     print(f"   Local:   http://localhost:{args.port}{suffix}")
-    if local_ip != "localhost":
+    # Only when actually reachable from the LAN: bound to loopback, that URL
+    # would be a lie, and the user would waste time trying it from a phone.
+    if local_ip != "localhost" and args.host not in ("127.0.0.1", "localhost", "::1"):
         print(f"   Network: http://{local_ip}:{args.port}{suffix}")
     print(f"\nℹ️  Presiona Ctrl+C para detener el servidor")
     print("="*60 + "\n")
 
     uvicorn.run(
         "disk_analyzer_web:app",
-        host="0.0.0.0",
+        host=args.host,
         port=args.port,
         reload=True,
         log_level="info",

--- a/docs/runbooks/app-bandeja.md
+++ b/docs/runbooks/app-bandeja.md
@@ -11,10 +11,38 @@ desinstalarla del todo y volver atrás cuando algo sale mal.
 
 ## Qué lleva dentro, y qué le falta
 
-La `.app` es **autocontenida**: pesa unos 92 MB porque lleva su propio CPython
+La `.app` es **autocontenida**: pesa unos 122 MB porque lleva su propio CPython
 —una compilación de [python-build-standalone](https://github.com/astral-sh/python-build-standalone),
-recortada— y una copia del motor de análisis. No necesita este repositorio, ni
-`venv-web`, ni ningún Python instalado en el sistema. Se puede mover a otro Mac.
+recortada—, una copia del motor de análisis y el servidor web completo con sus
+dependencias (FastAPI, uvicorn) y el frontend ya construido. No necesita este
+repositorio, ni `venv-web`, ni ningún Python instalado en el sistema. Se puede
+mover a otro Mac.
+
+## "Abrir analizador completo"
+
+El ítem arranca el servidor web empaquetado y abre el navegador en él. Si ya
+había uno escuchando en el 8000 —por ejemplo un `make web` tuyo—, lo reutiliza
+en vez de pelearse por el puerto.
+
+**Se ata solo a `127.0.0.1`, no a toda la red.** El servidor por defecto escucha
+en `0.0.0.0` porque el acceso desde otros dispositivos es una función
+documentada de `make web`. Pero desde la bandeja lo arranca un clic, y la
+interfaz web incluye una terminal que corre con tus privilegios: publicarla en
+la red sin que nadie lo haya pedido sería una sorpresa desagradable. La app le
+pasa `--host 127.0.0.1`, un flag que se añadió para esto.
+
+El token de autenticación viaja por la variable de entorno
+`DISK_ANALYZER_TOKEN`, no por la línea de órdenes: el servidor corre con
+`reload=True`, así que uvicorn reimporta el módulo en un subproceso y lo que
+solo existe en el bloque `__main__` no llega al worker que atiende las
+peticiones.
+
+Al salir de la app, el servidor muere con ella. Se lanza en su propio grupo de
+procesos justamente por eso: uvicorn con recarga levanta un worker aparte, y
+matar solo al proceso lanzado dejaría ese worker vivo ocupando el puerto.
+
+Si algo va mal, el propio ítem del menú lo dice ("No se pudo abrir: …") en vez
+de abrir una pestaña con un error de conexión, que es lo que hacía antes.
 
 Lo que sí le falta: **no está firmada ni notarizada** (decisión D4, sin cuenta de
 desarrollador de Apple). Gatekeeper la bloquea con doble clic; hay que abrirla la

--- a/tests/test_host_binding.py
+++ b/tests/test_host_binding.py
@@ -1,0 +1,114 @@
+"""El servidor tiene que poder atarse solo a loopback.
+
+La app de bandeja arranca este servidor con un solo clic, y la interfaz web
+incluye una terminal que corre con los privilegios del usuario. Exponer eso a
+toda la red sin que nadie lo haya pedido sería una sorpresa desagradable, así
+que la app pasa `--host 127.0.0.1`.
+
+El valor por defecto sigue siendo 0.0.0.0: el acceso desde otros dispositivos
+de la red es una función documentada de `make web`.
+
+Estos tests arrancan el servidor de verdad y comprueban desde qué direcciones
+responde. Mirar el texto del fuente no serviría: el flag podría existir y no
+llegar a uvicorn, que es precisamente la forma en que esto se rompe en
+silencio.
+"""
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+RAIZ = Path(__file__).resolve().parent.parent
+
+
+def _puerto_libre() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _ip_de_red():
+    """La IP no-loopback de esta máquina, o None si no tiene."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.connect(("8.8.8.8", 80))
+            ip = s.getsockname()[0]
+        return None if ip.startswith("127.") else ip
+    except OSError:
+        return None
+
+
+def _acepta(host: str, puerto: int, espera: float = 0.6) -> bool:
+    try:
+        with socket.create_connection((host, puerto), timeout=espera):
+            return True
+    except OSError:
+        return False
+
+
+def _arrancar(host: str, puerto: int):
+    entorno = dict(os.environ, DISK_ANALYZER_NO_AUTH="1")
+    proc = subprocess.Popen(
+        [sys.executable, "disk_analyzer_web.py", "--port", str(puerto), "--host", host],
+        cwd=RAIZ, env=entorno,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+        start_new_session=True,   # grupo propio: se mata entero, sin huérfanos
+    )
+    limite = time.time() + 30
+    while time.time() < limite:
+        if _acepta("127.0.0.1", puerto):
+            return proc
+        if proc.poll() is not None:
+            pytest.skip("el servidor no arrancó en este entorno")
+        time.sleep(0.25)
+    _parar(proc)
+    pytest.skip("el servidor tardó demasiado en arrancar")
+
+
+def _parar(proc):
+    try:
+        os.killpg(os.getpgid(proc.pid), 15)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        os.killpg(os.getpgid(proc.pid), 9)
+        proc.wait(timeout=5)
+
+
+def test_atado_a_loopback_no_responde_desde_la_red():
+    """El caso que protege al usuario de la app de bandeja."""
+    ip = _ip_de_red()
+    if ip is None:
+        pytest.skip("esta máquina no tiene IP de red que comprobar")
+    puerto = _puerto_libre()
+    proc = _arrancar("127.0.0.1", puerto)
+    try:
+        assert _acepta("127.0.0.1", puerto), "no responde ni en loopback"
+        assert not _acepta(ip, puerto), (
+            f"responde en {ip}:{puerto}: la terminal web quedaría expuesta a "
+            "toda la red pese a haber pedido solo loopback"
+        )
+    finally:
+        _parar(proc)
+
+
+def test_por_defecto_sigue_escuchando_en_toda_la_red():
+    """El acceso por LAN de `make web` está documentado; no se rompe."""
+    ip = _ip_de_red()
+    if ip is None:
+        pytest.skip("esta máquina no tiene IP de red que comprobar")
+    puerto = _puerto_libre()
+    proc = _arrancar("0.0.0.0", puerto)
+    try:
+        assert _acepta(ip, puerto), (
+            f"no responde en {ip}:{puerto}: se rompió el acceso desde otros "
+            "dispositivos, que es una función documentada"
+        )
+    finally:
+        _parar(proc)


### PR DESCRIPTION
El ítem abría `http://localhost:8000/` **dando por hecho que el servidor ya estaba corriendo**. En la app empaquetada no podía estarlo nunca: el bundle no llevaba el servidor. El resultado era un botón que abría una pestaña con un error de conexión.

## Qué cambia

El bundle lleva ahora el servidor web completo —FastAPI, uvicorn y el frontend construido, unos 30 MB más— y el ítem lo arranca, espera a que acepte conexiones y abre el navegador en él. Si ya hay uno escuchando en el 8000 (un `make web` tuyo), lo reutiliza en vez de pelearse por el puerto.

La `.app` pasa de 92 a 122 MB; el `.zip` de 35 a 45 MB.

## Seguridad: se ata a loopback

El servidor **no tenía forma de elegir interfaz**: `host="0.0.0.0"` estaba fijo en el código. Desde la bandeja lo arranca un solo clic, y la interfaz web incluye una terminal que corre con los privilegios del usuario — publicarla en toda la red sin que nadie lo pidiera sería una sorpresa desagradable.

El flag `--host` es nuevo. **Su defecto sigue siendo `0.0.0.0`**, porque el acceso desde otros dispositivos es una función documentada de `make web`; la app de bandeja pasa `127.0.0.1`. De paso, el banner de arranque deja de anunciar una URL de red cuando no la hay.

Los tests arrancan el servidor **de verdad** y comprueban desde qué direcciones responde, en vez de mirar el texto del fuente: el flag podía existir y no llegar a uvicorn, que es justo como esto se rompe en silencio. Verificado por mutación — con el flag ignorado, el test falla con `responde en 192.168.1.x:port: la terminal web quedaría expuesta a toda la red`.

## Verificación sobre la .app instalada

- El servidor arranca atado **solo a `127.0.0.1:8000`**; desde la IP de red la conexión es rechazada.
- El navegador abre el dashboard, y el token desaparece de la URL — el frontend lo guarda en `sessionStorage` y la limpia.
- Al pulsar "Salir" mueren **los dos** procesos del servidor, incluido el worker de recarga de uvicorn. Por eso se lanza en su propio grupo de procesos.
- `make test`: 236 en verde (153 backend + 69 frontend + 17 Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)