### PR TITLE
fix(web): decir que el servidor no está, en vez de callarse

### DIFF
--- a/web/src/components/AuthErrorBanner.tsx
+++ b/web/src/components/AuthErrorBanner.tsx
@@ -1,8 +1,10 @@
 /**
  * AuthErrorBanner — persistent component mounted in MainLayout.
  *
- * Shows a fixed top banner when the server rejects the token in
- * sessionStorage (HTTP 401 on a REST call, or WebSocket close code 1008).
+ * Shows a fixed top banner for the two ways the API stops answering: the
+ * server rejects the token in sessionStorage (HTTP 401, or WebSocket close
+ * code 1008), or the server is not reachable at all (the fetch rejects before
+ * there is any response).
  * This is the ordinary "restart the server, reload the tab" flow — the
  * server mints a fresh token per run, so the browser's cached one goes
  * stale and every request/socket fails until the user opens the new
@@ -16,16 +18,26 @@
 import { useState, useEffect } from 'react';
 import { on } from '../lib/events';
 import { AUTH_INVALID_EVENT } from '../lib/auth';
+import { SERVER_DOWN_EVENT } from '../lib/api';
 
-const MESSAGE =
-  'Session expired or invalid token. The server prints a new link with a fresh token every time it starts — open that link again to reconnect.';
+// Both messages point at the same remedy — reopen the link — but naming the
+// actual cause matters: "sesión caducada" sends the user looking for a login
+// that does not exist, when the real problem is that nothing is listening.
+const MENSAJE_SESION =
+  'Sesión caducada o token inválido. El servidor genera un enlace con un token nuevo cada vez que arranca: vuelve a abrir ese enlace para reconectar.';
+
+const MENSAJE_SERVIDOR_CAIDO =
+  'No hay conexión con el servidor: no está corriendo. Si lo abriste desde el icono de la barra, vuelve a pulsar "Abrir analizador completo" — el servidor se cierra junto con la app, y al arrancar de nuevo genera otro token, así que esta pestaña ya no vale.';
 
 export default function AuthErrorBanner() {
-  const [visible, setVisible] = useState(false);
+  const [mensaje, setMensaje] = useState<string | null>(null);
 
-  useEffect(() => on(AUTH_INVALID_EVENT, () => setVisible(true)), []);
+  useEffect(() => on(AUTH_INVALID_EVENT, () => setMensaje(MENSAJE_SESION)), []);
+  // El servidor caído gana: si no hay nadie escuchando, hablar de tokens
+  // manda al usuario a buscar el problema donde no está.
+  useEffect(() => on(SERVER_DOWN_EVENT, () => setMensaje(MENSAJE_SERVIDOR_CAIDO)), []);
 
-  if (!visible) return null;
+  if (!mensaje) return null;
 
   return (
     <div
@@ -48,10 +60,10 @@ export default function AuthErrorBanner() {
         boxShadow: '0 2px 8px rgba(0,0,0,0.2)',
       }}
     >
-      <span>{MESSAGE}</span>
+      <span>{mensaje}</span>
       <button
-        onClick={() => setVisible(false)}
-        aria-label="Dismiss"
+        onClick={() => setMensaje(null)}
+        aria-label="Descartar"
         style={{
           background: 'transparent',
           border: '1px solid rgba(255,255,255,0.6)',

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Qué hace `request()` cuando el API deja de responder.
+ *
+ * Son dos fallos distintos y hasta ahora solo uno estaba cubierto:
+ *
+ * - **401**: hay servidor, pero rechaza el token. Ya avisaba.
+ * - **Sin conexión**: no hay servidor. `fetch` rechaza antes de que exista
+ *   ninguna respuesta que mirar, así que se colaba por debajo de todas las
+ *   ramas: la pestaña llenaba la consola de ERR_CONNECTION_REFUSED y la
+ *   página parecía colgada, sin decir nada.
+ *
+ * El segundo caso pasa de forma rutinaria: la app de bandeja arranca este
+ * servidor y lo mata al salir, dejando las pestañas abiertas apuntando a un
+ * puerto muerto.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { api, SERVER_DOWN_EVENT } from './api';
+import { AUTH_INVALID_EVENT } from './auth';
+
+function espiarEvento(nombre: string) {
+  const espia = vi.fn();
+  window.addEventListener(nombre, espia);
+  return { espia, quitar: () => window.removeEventListener(nombre, espia) };
+}
+
+describe('request cuando el API no responde', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    sessionStorage.clear();
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Va el primero a propósito: el aviso de servidor caído se deduplica por
+  // carga de página, así que si este test corriera después, el "no se avisó"
+  // pasaría por el deduplicado en vez de por la lógica.
+  it('un 401 sigue avisando de token inválido, no de servidor caído', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ status: 401, ok: false, text: async () => '' }),
+    );
+    const { espia: espiaAuth, quitar: q1 } = espiarEvento(AUTH_INVALID_EVENT);
+    const { espia: espiaCaido, quitar: q2 } = espiarEvento(SERVER_DOWN_EVENT);
+    try {
+      await expect(api.createTerminal()).rejects.toThrow(/401/);
+      expect(espiaAuth).toHaveBeenCalled();
+      expect(espiaCaido).not.toHaveBeenCalled();
+    } finally {
+      q1();
+      q2();
+    }
+  });
+
+  it('avisa de que el servidor no está cuando fetch ni siquiera conecta', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    );
+    const { espia, quitar } = espiarEvento(SERVER_DOWN_EVENT);
+    try {
+      await expect(api.createTerminal()).rejects.toThrow(
+        /No se pudo conectar con el servidor/,
+      );
+      expect(espia).toHaveBeenCalled();
+    } finally {
+      quitar();
+    }
+  });
+
+  it('no confunde un servidor caído con un token caducado', async () => {
+    // Decir "sesión caducada" cuando no hay nadie escuchando manda al usuario
+    // a buscar el problema donde no está.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockRejectedValue(new TypeError('Failed to fetch')),
+    );
+    const { espia: espiaAuth, quitar } = espiarEvento(AUTH_INVALID_EVENT);
+    try {
+      await expect(api.createTerminal()).rejects.toThrow();
+      expect(espiaAuth).not.toHaveBeenCalled();
+    } finally {
+      quitar();
+    }
+  });
+
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2,6 +2,28 @@ import { authHeaders, notifyAuthInvalid } from './auth';
 
 const BASE = '/api';
 
+/**
+ * Fired when the server can't be reached at all — the fetch itself rejects
+ * before there is any response to inspect.
+ *
+ * This is not the same as a 401, and it used to fall through every branch of
+ * `request()`: the tab just filled the console with ERR_CONNECTION_REFUSED
+ * and the page looked frozen. It happens routinely, because the menu-bar app
+ * starts this server and kills it again when the app quits, leaving whatever
+ * tabs were open pointing at a dead port.
+ */
+export const SERVER_DOWN_EVENT = 'server:down';
+
+// Deduped for the same reason as the auth notification: a single click can
+// fire several parallel calls, and one banner per failed call would be noise.
+let servidorCaidoAvisado = false;
+
+function notifyServerDown(): void {
+  if (typeof window === 'undefined' || servidorCaidoAvisado) return;
+  servidorCaidoAvisado = true;
+  window.dispatchEvent(new CustomEvent(SERVER_DOWN_EVENT));
+}
+
 export interface SystemInfo {
   platform: string;
   hostname: string;
@@ -94,10 +116,18 @@ export interface SessionResults {
 }
 
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    ...options,
-    headers: { 'Content-Type': 'application/json', ...authHeaders(), ...(options?.headers ?? {}) },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}${path}`, {
+      ...options,
+      headers: { 'Content-Type': 'application/json', ...authHeaders(), ...(options?.headers ?? {}) },
+    });
+  } catch (e) {
+    // `fetch` only rejects when the request never got a reply: server down,
+    // DNS, connection refused. Anything with a status code lands below.
+    notifyServerDown();
+    throw new Error(`No se pudo conectar con el servidor: ${(e as Error).message}`);
+  }
   if (res.status === 401) {
     // Stale/invalid token — most commonly because the server was restarted
     // (it mints a new token per run) and this tab still has the old one in


### PR DESCRIPTION
Cuando el servidor no responde, `fetch` rechaza **antes de que exista ninguna respuesta que mirar**, así que se colaba por debajo de todas las ramas de `request()`: ni el 401 ni el `!res.ok`. La pestaña llenaba la consola de `ERR_CONNECTION_REFUSED` y la página parecía colgada, sin decir nada.

Pasa de forma rutinaria desde que la app de bandeja arranca el servidor: **se cierra junto con la app**, dejando las pestañas abiertas apuntando a un puerto muerto. Y al volver a arrancar genera otro token, así que recargar la pestaña vieja tampoco sirve — el mensaje lo dice explícitamente.

## Por qué no reutilizar el mensaje de sesión caducada

Decir "sesión caducada" cuando no hay nadie escuchando manda al usuario a buscar el problema donde no está. Son dos fallos distintos y ahora se distinguen: 401 (hay servidor, rechaza el token) frente a sin conexión (no hay servidor).

De paso, el banner estaba en inglés pese a que la interfaz declara `lang="es"` y la convención del proyecto pide español de cara al usuario. Traducido.

## Sobre los tests

El del 401 va **primero a propósito**: el aviso de servidor caído se deduplica por carga de página, así que corriendo después su "no se avisó" pasaría por el deduplicado en vez de por la lógica. Verificado por mutación — quitando el `try/catch`, el test cae.

🤖 Generated with [Claude Code](https://claude.com/claude-code)