### PR TITLE
fix: saneamiento de la limpieza — inyección de shell, verja de borrado y un solo motor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,38 @@ There is a phased improvement plan in progress. **Before starting work on the ba
 - `docs/superpowers/plans/2026-07-15-roadmap-mejoras.md` — the deep assessment (19 verified findings) and the scope of the 6 phases
 - `docs/superpowers/plans/2026-07-15-registro-ejecucion.md` — what was actually implemented, with commits, approved plan deviations, and deferred findings
 
-Current state: Phases 1 (backend bugs), 2 (security), 3 (shared engine) and 5 (tests + CI) are all merged to `main`. Phase 4 (frontend) is complete on `feat/fase4-frontend`, pending merge: the frontend now has its own test suite (66 tests, `npm test` inside `web/`, wired into CI and `make test`), and every cleanup flow (`QuickActions`, `CleanupWizard`, `GuidedDeclutter`, `WhatIfSandbox`, `ReverseView`, `DockerPanel`) runs its commands through the single shared `useCleanupRunner` hook — it's the only thing that talks to `api.createTerminal`/tracks `terminal:exited` for cleanup, and it only credits savings when a command exits 0. Auth is on by default: the server prints a link with a one-time token (`http://localhost:8000/?token=...`) on startup, the frontend stores it in `sessionStorage` and strips it from the URL, and a new token is minted on every restart — reopen the printed link after restarting the server. Use `--no-auth` to disable this on an isolated network.
+Current state: Phases 1 (backend bugs), 2 (security), 3 (shared engine) and 5 (tests + CI) are all merged to `main`. Phase 4 (frontend) is complete on `feat/fase4-frontend`, pending merge: the frontend now has its own test suite (66 tests, `npm test` inside `web/`, wired into CI and `make test`), and every cleanup flow (`QuickActions`, `CleanupWizard`, `GuidedDeclutter`, `WhatIfSandbox`, `ReverseView`, `DockerPanel`) runs its commands through the single shared `useCleanupRunner` hook — it's the only thing that talks to `api.createTerminal`/tracks `terminal:exited` for cleanup, and it credits savings by measuring free disk space before and after, not by
+trusting the exit code — `rm -f` returns 0 whether it deleted everything or
+nothing. Auth is on by default: the server prints a link with a one-time token (`http://localhost:8000/?token=...`) on startup, the frontend stores it in `sessionStorage` and strips it from the URL, and a new token is minted on every restart — reopen the printed link after restarting the server. Use `--no-auth` to disable this on an isolated network.
+
+## Safety invariant: the deletion gate
+
+`analyzer/protection.py::puede_borrarse` is the whitelist that decides what an
+automatic deletion may touch. It is **stricter and different** from
+`is_protected_path`, which only says "this belongs to the OS".
+
+Every path that reaches a deletion must pass it. It is installed at the three
+places that delete:
+
+- `analyzer/comandos.py` — `borrar_contenido`/`borrar_rutas` drop paths that
+  fail the gate, so every generated shell command is filtered. Never build a
+  deletion command by interpolating a path yourself; that is how a folder named
+  `x' ; rm -rf victim ; '` came to execute arbitrary commands.
+- `disk_analyzer.py::clean_cache` — bulk permanent deletion from the CLI.
+- `disk_analyzer_web.py::_perform_cleanup_deletes` — bulk deletion from the API.
+
+`/api/files/delete` deliberately still uses `is_protected_path`: it is a
+single file the user picked, and on macOS it moves to the Finder trash.
+
+**Two rules that exist because breaking them cost real data:**
+
+1. **No cleanup rule filters by `cache_types` alone — always scope by path too.**
+   A rule filtered by `type == XCODE` and shipped deleting the user's
+   `.xcarchive` files (signed builds and dSYMs, which never regenerate) with a
+   description that read "they regenerate when you build".
+2. **`cache_types.classify()` must never see the username.** It matches
+   substrings, so a user named `logan` had `~/Downloads` classified as system
+   logs — and `make clean-cache` deleted it permanently.
 
 ## Build and Test Commands
 

--- a/analyzer/cache_types.py
+++ b/analyzer/cache_types.py
@@ -9,6 +9,7 @@ Ported from DiskAnalyzerCore.categorize_cache (disk_analyzer_core.py), which
 both DiskAnalyzer.classify_cache (CLI) and DiskAnalyzerCore.categorize_cache
 now delegate to (Task 4 of the shared-engine refactor).
 """
+import os
 from pathlib import Path
 
 DOCKER = 'Docker'
@@ -52,6 +53,40 @@ ALL_LABELS = (
 SAFE_TO_CLEAN = frozenset({LOGS, VSCODE, NPM, XCODE})
 
 
+def _sin_nombre_de_usuario(path_str: str) -> str:
+    """Strips the home directory -- and with it, the username -- from a path
+    before classification looks at it.
+
+    `classify` matches on substrings of the *whole* lowercased path. A
+    macOS home directory is `/Users/<username>`, so before this stripping a
+    username that happens to contain 'log', 'code' or 'node' (e.g. 'logan',
+    'nicode', 'anode') made every single path under that user's home --
+    including `~/Downloads` -- match LOGS/VSCODE/NPM respectively, landing
+    it in SAFE_TO_CLEAN. Verified: user 'logan' -> `~/Downloads` classified
+    as LOGS.
+
+    Two strategies, tried in order:
+    1. Strip the real `$HOME` prefix, if the path is under it (covers the
+       common case, including non-`/Users` homes).
+    2. Generic fallback: if the path looks like `/Users/<name>/...` or
+       `/home/<name>/...` (a synthetic username that isn't the real $HOME,
+       as in tests and in multi-user scans), drop that two-component
+       prefix too.
+
+    Classification then runs on what's left -- 'Library/Logs', '.npm', etc
+    -- never on the username itself.
+    """
+    partes = Path(path_str).parts
+    home_partes = Path(os.path.expanduser('~')).parts
+    if len(partes) >= len(home_partes) and partes[:len(home_partes)] == home_partes:
+        resto = partes[len(home_partes):]
+        return str(Path(*resto)) if resto else ''
+    if len(partes) >= 3 and partes[1].lower() in ('users', 'home'):
+        resto = partes[3:]
+        return str(Path(*resto)) if resto else ''
+    return path_str
+
+
 def classify(path: Path) -> str:
     """Classify a cache location by path. Order matters: first match wins.
 
@@ -68,8 +103,11 @@ def classify(path: Path) -> str:
     'xcode' and 'node') now resolves to XCODE where the pre-fix code would
     have hit that later branch (e.g. NPM) instead. Only single-keyword paths
     are guaranteed unaffected by moving 'xcode' to the front.
+
+    The path is stripped of its home directory (username) before any of
+    this matching happens -- see `_sin_nombre_de_usuario`.
     """
-    path_str = str(path).lower()
+    path_str = _sin_nombre_de_usuario(str(path)).lower()
 
     if 'xcode' in path_str:
         return XCODE

--- a/analyzer/comandos.py
+++ b/analyzer/comandos.py
@@ -16,6 +16,8 @@ motor no tiene dependencias.
 import shlex
 from typing import List
 
+from analyzer.protection import puede_borrarse
+
 # Rutas que jamás pueden ser el objetivo de un comando generado, por muy
 # protegida que esté la lógica que llama aquí. Es la última red, no la primera.
 _PROHIBIDAS = {"/", "//", "/.", ""}
@@ -27,10 +29,21 @@ def escapar(path: str) -> str:
 
 
 def _utiles(paths: List[str]) -> List[str]:
+    """Limpia la lista y descarta lo que `puede_borrarse` rechace.
+
+    `protection.puede_borrarse` existía desde antes pero nadie fuera de sus
+    propios tests la llamaba: una verja de seguridad construida y no
+    instalada. Este es el paso obligado de todo comando de borrado que
+    genera el motor -- para esquivarla habría que evitar `comandos.py` por
+    completo, y ese es justo el módulo que toda regla de generate_recommendations
+    y detect_smart_recommendations ya usa para construir sus 'rm -rf'.
+    """
     limpias = []
     for p in paths:
         p = (p or "").rstrip("/") if (p or "").rstrip("/") else (p or "")
         if p.strip() in _PROHIBIDAS or not p.strip():
+            continue
+        if not puede_borrarse(p):
             continue
         limpias.append(p)
     return limpias

--- a/analyzer/comandos.py
+++ b/analyzer/comandos.py
@@ -1,0 +1,56 @@
+"""Único sitio donde se construyen comandos de borrado.
+
+Antes cada sitio armaba su propia f-string. Eso produjo dos fallos que llegaron
+a producción y se reprodujeron:
+
+- Una carpeta llamada `x' ; rm -rf victim ; touch pwned '` cerraba las comillas
+  de la plantilla y ejecutaba comandos arbitrarios. La ruta la aporta el escaneo
+  del disco, así que basta con descomprimir un zip con un nombre hostil.
+- El glob iba DENTRO de las comillas (`rm -rf 'dir/*'`), así que el shell no lo
+  expandía: `rm -f` salía 0 sin borrar nada, y la interfaz acreditaba el ahorro
+  al ver ese 0.
+
+`shlex.quote` es biblioteca estándar, así que esto no rompe la promesa de que el
+motor no tiene dependencias.
+"""
+import shlex
+from typing import List
+
+# Rutas que jamás pueden ser el objetivo de un comando generado, por muy
+# protegida que esté la lógica que llama aquí. Es la última red, no la primera.
+_PROHIBIDAS = {"/", "//", "/.", ""}
+
+
+def escapar(path: str) -> str:
+    """Deja una ruta lista para incrustarse en una línea de shell."""
+    return shlex.quote(path)
+
+
+def _utiles(paths: List[str]) -> List[str]:
+    limpias = []
+    for p in paths:
+        p = (p or "").rstrip("/") if (p or "").rstrip("/") else (p or "")
+        if p.strip() in _PROHIBIDAS or not p.strip():
+            continue
+        limpias.append(p)
+    return limpias
+
+
+def borrar_contenido(paths: List[str]) -> str:
+    """Borra lo que hay DENTRO de cada ruta, dejando el directorio en pie.
+
+    El glob va fuera de las comillas a propósito: dentro, el shell lo trata como
+    un nombre de fichero literal y el comando no borra nada.
+    """
+    limpias = _utiles(paths)
+    if not limpias:
+        return ""
+    return " && ".join(f"rm -rf {escapar(p)}/*" for p in limpias)
+
+
+def borrar_rutas(paths: List[str]) -> str:
+    """Borra cada ruta entera, el directorio incluido."""
+    limpias = _utiles(paths)
+    if not limpias:
+        return ""
+    return " && ".join(f"rm -rf {escapar(p)}" for p in limpias)

--- a/analyzer/constants.py
+++ b/analyzer/constants.py
@@ -110,6 +110,37 @@ PROTECTED_PATH_PREFIXES = [
     '/private/var/folders/',
 ]
 
+# Rutas cuyo borrado destruye datos del usuario. `PROTECTED_PATH_PREFIXES` es
+# una lista negra del sistema operativo y no cubre nada de esto: verificado que
+# ~/Documents, iCloud Drive y /Volumes/... salían como borrables.
+#
+# Se guardan relativas a $HOME (o absolutas cuando no dependen del usuario) y se
+# expanden al comprobar, para que los tests no dependan de quién ejecuta.
+RUTAS_DE_DATOS_DE_USUARIO = [
+    '~',
+    '~/Documents',
+    '~/Desktop',
+    '~/Pictures',
+    '~/Movies',
+    '~/Music',
+    '~/Library/Mobile Documents',   # iCloud Drive
+    '~/Library/Messages',
+    '~/Library/Mail',
+    '~/Library/Photos',
+    '~/Library/Keychains',
+    '~/Library/Application Support/MobileSync',  # backups de iPhone
+    '/Volumes',                     # discos externos y Time Machine
+    '/Users',
+    '/System',
+    '/Library',
+    '/private',
+    '/usr',
+    '/etc',
+    '/var',
+    '/opt',
+    '/Applications',
+]
+
 # Prefijos que protegen internos de apps (Contents/ dentro de un .app o .AppBundle)
 # pero NO el .app en sí (el usuario puede borrar una app entera)
 PROTECTED_APP_MARKERS = ['.app/', '.AppBundle/']

--- a/analyzer/protection.py
+++ b/analyzer/protection.py
@@ -1,22 +1,135 @@
 """Protected-path detection, shared by the CLI, core engine and web backend."""
 
+import os
 from pathlib import Path
 
 from analyzer.constants import (
     PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
-    PROTECTED_ROOT_DIRS,
+    PROTECTED_ROOT_DIRS, RUTAS_DE_DATOS_DE_USUARIO,
 )
 
 
 def is_protected_path(file_path: str) -> bool:
     """Determina si un archivo es del sistema y no debe borrarse"""
-    if any(file_path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
-        return True
-    parts = Path(file_path).parts
+    # APFS no distingue mayúsculas de minúsculas por defecto (sí las
+    # conserva): '/bin' y '/BIN' son el mismo directorio. Las cuatro
+    # comprobaciones de abajo se hacen sobre la forma en minúsculas para que
+    # cambiar la caja no sea una manera de esquivarlas -- normalizar solo
+    # amplía lo protegido, nunca lo reduce.
+    ruta_cf = file_path.lower()
+
+    # `startswith('/System/Library/')` no cubre '/System/Library' a secas, así
+    # que el directorio en sí quedaba desprotegido y solo lo estaba su contenido.
+    for prefix in PROTECTED_PATH_PREFIXES:
+        prefix_cf = prefix.lower()
+        if ruta_cf.startswith(prefix_cf) or ruta_cf == prefix_cf.rstrip('/'):
+            return True
+    parts = Path(ruta_cf).parts
     if len(parts) >= 2 and '/' + parts[1] in PROTECTED_ROOT_DIRS:
         return True
-    if '/Contents/' in file_path and any(m in file_path for m in PROTECTED_APP_MARKERS):
+    if '/contents/' in ruta_cf and any(m.lower() in ruta_cf for m in PROTECTED_APP_MARKERS):
         return True
-    if Path(file_path).name in PROTECTED_FILENAMES:
+    if Path(ruta_cf).name in PROTECTED_FILENAMES:
         return True
     return False
+
+
+def _normalizar(file_path: str):
+    """Expande, exige ruta absoluta y resuelve enlaces simbólicos.
+
+    Devuelve `None` si `file_path` no es una ruta absoluta utilizable (vacía,
+    solo espacios, o relativa). Se rechaza la ruta relativa ANTES de
+    `abspath()`: `abspath()` siempre devuelve algo absoluto anclado al cwd de
+    quien llama, así que comprobarlo después sería código muerto que solo
+    "funciona" si el cwd cae, por accidente, bajo un prefijo ya prohibido.
+
+    Se resuelven enlaces simbólicos (no solo '..' léxico) porque
+    `borrar_contenido` ejecuta `rm -rf <ruta>/*`, y ese glob SÍ atraviesa un
+    enlace dentro de un directorio permitido hacia dondequiera que apunte. De
+    paso, en macOS esto normaliza /var, /tmp y /etc a su ubicación real bajo
+    /private.
+
+    Compartida por `puede_borrarse` y `_coincide_con_permitidas` para que
+    ambas apliquen exactamente la misma normalización.
+    """
+    if not file_path or not file_path.strip():
+        return None
+    expandida = os.path.expanduser(file_path)
+    if not os.path.isabs(expandida):
+        return None
+    ruta = os.path.realpath(os.path.normpath(os.path.abspath(expandida)))
+    if ruta == '/':
+        return None
+    return ruta
+
+
+def _coincide_con_permitidas(file_path: str) -> bool:
+    """Si `file_path` cae dentro de una de las cachés conocidas y seguras de
+    borrar.
+
+    Aislada de `puede_borrarse` a propósito, para poder testear la
+    coincidencia en sí. `puede_borrarse` puede devolver `True` por su
+    `return True` final aunque esta coincidencia nunca se produzca (por
+    ejemplo, si ninguna otra regla bloquea la ruta) -- un test que solo mira
+    el resultado de `puede_borrarse` no puede distinguir "es una caché
+    conocida" de "no coincidió nada que la prohibiera".
+    """
+    ruta = _normalizar(file_path)
+    if ruta is None:
+        return False
+    ruta_cf = ruta.lower()
+
+    permitidas = [
+        os.path.realpath(os.path.expanduser('~/Library/Caches')),
+        os.path.realpath(os.path.expanduser('~/Library/Logs')),
+        os.path.realpath(os.path.expanduser('~/.cache')),
+        os.path.realpath(os.path.expanduser('~/.npm')),
+        os.path.realpath(os.path.expanduser('~/Library/Developer/Xcode/DerivedData')),
+        os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/Cache')),
+        os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/CachedData')),
+        os.path.realpath(os.path.expanduser('~/Library/Containers/com.docker.docker/Data')),
+    ]
+    return any(ruta_cf == p.lower() or ruta_cf.startswith(p.lower() + '/') for p in permitidas)
+
+
+def puede_borrarse(file_path: str) -> bool:
+    """Si una ruta puede ser objetivo de un borrado automático.
+
+    Distinta de `is_protected_path`, que solo dice "esto es del sistema
+    operativo". Aquí la pregunta es la contraria y más estricta: ¿es seguro que
+    una herramienta borre esto sin que un humano lo mire? Ante la duda, no.
+
+    Se normaliza antes de comparar porque
+    `~/Library/Caches/../../Documents` es `~/Documents` disfrazado.
+    """
+    ruta = _normalizar(file_path)
+    if ruta is None:
+        return False
+
+    # APFS no distingue mayúsculas de minúsculas por defecto (sí las
+    # conserva): '/Volumes/x' y '/volumes/x' son el mismo directorio. Sin
+    # normalizar la caja aquí, cambiar la caja de una ruta prohibida basta
+    # para colarla hasta el `return True` final.
+    ruta_cf = ruta.lower()
+
+    if is_protected_path(ruta):
+        return False
+
+    for cruda in RUTAS_DE_DATOS_DE_USUARIO:
+        prohibida = os.path.realpath(os.path.expanduser(cruda))
+        # La ruta prohibida en sí, y todo lo que cuelga de ella salvo que una
+        # regla más específica lo permita (ver abajo).
+        if ruta_cf == prohibida.lower():
+            return False
+
+    # Dentro de una zona prohibida solo se salvan las cachés conocidas: eso es
+    # lo que convierte esto en whitelist y no en otra lista negra.
+    if _coincide_con_permitidas(ruta):
+        return True
+
+    for cruda in RUTAS_DE_DATOS_DE_USUARIO:
+        prohibida = os.path.realpath(os.path.expanduser(cruda))
+        if ruta_cf.startswith(prohibida.lower() + '/'):
+            return False
+
+    return True

--- a/analyzer/protection.py
+++ b/analyzer/protection.py
@@ -87,7 +87,25 @@ def _coincide_con_permitidas(file_path: str) -> bool:
         os.path.realpath(os.path.expanduser('~/Library/Developer/Xcode/DerivedData')),
         os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/Cache')),
         os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/CachedData')),
-        os.path.realpath(os.path.expanduser('~/Library/Containers/com.docker.docker/Data')),
+        # NOTA: ~/Library/Containers/com.docker.docker/Data estuvo aquí y se
+        # quitó (revisión final, ola de saneamiento). Buscado: ninguna regla
+        # de generate_recommendations ni de detect_smart_recommendations
+        # genera un comando de borrado contra esta ruta -- la limpieza de
+        # Docker siempre pasa por `docker system prune`/`docker volume`/
+        # `docker image`, nunca por un rm -rf directo sobre este directorio.
+        # find_cache_locations() sí lo escanea (está en CACHE_DIRS, clasifica
+        # como cache_types.DOCKER) y por eso puede llegar como 'action' al
+        # endpoint web de limpieza con una categoría "Docker" elegida a mano
+        # -- ese es el único camino real hacia _perform_cleanup_deletes que
+        # podía tocarlo, y es justo el que este fix (Task 2) empieza a pasar
+        # por puede_borrarse. Bajo esa ruta viven los volúmenes con NOMBRE de
+        # Docker -- bases de datos y otros datos persistentes del usuario,
+        # no una caché regenerable -- así que estar en esta whitelist era un
+        # borrado silencioso de datos de usuario esperando un disparador. Si
+        # se necesita una regla real de "liberar espacio de Docker por
+        # tamaño de disco" en el futuro, debe ir por `docker system prune`
+        # como las demás, no reabrir esta entrada.
+        #
         # El usuario ya decidió tirar esto -- vaciar la papelera es la regla
         # de nivel 1 de generate_recommendations() (id 'papelera').
         os.path.realpath(os.path.expanduser('~/.Trash')),

--- a/analyzer/protection.py
+++ b/analyzer/protection.py
@@ -126,6 +126,19 @@ def puede_borrarse(file_path: str) -> bool:
     if is_protected_path(ruta):
         return False
 
+    # Segundo eje de la verja: por NOMBRE, no por ubicación. `_coincide_con_permitidas`
+    # es una whitelist de rutas fijas -- pero detect_smart_recommendations()
+    # encuentra `node_modules` huérfanos en rutas arbitrarias del usuario
+    # (cualquier proyecto, en cualquier parte), así que no hay una ubicación
+    # fija que añadir ahí. `node_modules` se regenera con `npm install`: el
+    # nombre por sí solo basta para considerarlo seguro, siempre que
+    # `is_protected_path` ya lo haya dejado pasar (arriba). Deliberadamente
+    # estrecho -- SOLO este nombre exacto, nada de listas de patrones
+    # abiertas. No añadir más casos de este eje sin una decisión de producto
+    # explícita (ver tests/test_puede_borrarse.py).
+    if Path(ruta).name == 'node_modules':
+        return True
+
     for cruda in RUTAS_DE_DATOS_DE_USUARIO:
         prohibida = os.path.realpath(os.path.expanduser(cruda))
         # La ruta prohibida en sí, y todo lo que cuelga de ella salvo que una

--- a/analyzer/protection.py
+++ b/analyzer/protection.py
@@ -88,6 +88,17 @@ def _coincide_con_permitidas(file_path: str) -> bool:
         os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/Cache')),
         os.path.realpath(os.path.expanduser('~/Library/Application Support/Code/CachedData')),
         os.path.realpath(os.path.expanduser('~/Library/Containers/com.docker.docker/Data')),
+        # El usuario ya decidió tirar esto -- vaciar la papelera es la regla
+        # de nivel 1 de generate_recommendations() (id 'papelera').
+        os.path.realpath(os.path.expanduser('~/.Trash')),
+        # Igual que DerivedData arriba: una ruta con nombre fijo bajo
+        # Library/Developer/Xcode, no una clasificación por `type`. No es lo
+        # mismo que el bug de cache_types.XCODE que confundía DerivedData con
+        # Archives por type -- aquí es detect_smart_recommendations()
+        # (id 'xcode_archives_antiguos') apuntando a esta ruta exacta, con su
+        # propio umbral de tamaño (>1GB) y descripción honesta sobre qué
+        # implica borrarlo.
+        os.path.realpath(os.path.expanduser('~/Library/Developer/Xcode/Archives')),
     ]
     return any(ruta_cf == p.lower() or ruta_cf.startswith(p.lower() + '/') for p in permitidas)
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -179,7 +179,7 @@ pub fn run() {
                     .on_menu_event(move |app, event| {
                         if event.id() == "quit" {
                             // El servidor web también: lo arrancamos nosotros,
-                            // así que no debe sobrevivirnos ocupando el 8000.
+                            // así que no debe sobrevivirnos ocupando su puerto.
                             servidor.kill_blocking();
                             // Block briefly (bounded by KILL_REAP_TIMEOUT)
                             // so the scan's process group is confirmed dead

--- a/desktop/src-tauri/src/servidor.rs
+++ b/desktop/src-tauri/src/servidor.rs
@@ -28,7 +28,6 @@ use std::time::{Duration, Instant};
 
 use crate::analisis::Motor;
 
-const PUERTO: u16 = 8000;
 const HOST: &str = "127.0.0.1";
 /// Cuánto se espera a que el servidor acepte conexiones. Arrancar FastAPI y
 /// uvicorn lleva varios segundos en frío; medido en esta máquina, entre 8 y
@@ -38,20 +37,41 @@ const ARRANQUE_MAXIMO: Duration = Duration::from_secs(45);
 const SONDEO: Duration = Duration::from_millis(250);
 const TERM_GRACE: Duration = Duration::from_millis(300);
 
-fn direccion() -> SocketAddr {
-    SocketAddr::from(([127, 0, 0, 1], PUERTO))
+fn direccion(puerto: u16) -> SocketAddr {
+    SocketAddr::from(([127, 0, 0, 1], puerto))
 }
 
 /// Si algo acepta conexiones en el puerto. No distingue *qué* escucha: eso lo
-/// resuelve `Servidor`, que sabe si la instancia es suya.
-fn puerto_ocupado() -> bool {
-    match TcpStream::connect_timeout(&direccion(), Duration::from_millis(400)) {
+/// resuelve `Servidor::es_nuestra_instancia`, que sabe si la instancia es
+/// suya.
+fn acepta(puerto: u16) -> bool {
+    match TcpStream::connect_timeout(&direccion(puerto), Duration::from_millis(400)) {
         Ok(s) => {
             let _ = s.shutdown(Shutdown::Both);
             true
         }
         Err(_) => false,
     }
+}
+
+/// Pide al sistema un puerto libre.
+///
+/// Atar el 0 hace que el kernel asigne uno sin usar; se suelta acto seguido y
+/// se le pasa al servidor. Queda una ventana mínima en la que otro proceso
+/// podría cogerlo, y por eso quien llama reintenta.
+///
+/// El 8000 fijo que había antes es un puerto muy disputado (Django, Rails,
+/// http.server). Y como la app abre el navegador ella misma, el número nunca
+/// lo ve el usuario: fijarlo solo servía para chocar.
+fn puerto_libre() -> Result<u16, String> {
+    let l = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|e| format!("no se pudo pedir un puerto libre: {e}"))?;
+    let p = l
+        .local_addr()
+        .map_err(|e| format!("no se pudo leer el puerto asignado: {e}"))?
+        .port();
+    drop(l);
+    Ok(p)
 }
 
 /// Token de un solo uso para esta instancia del servidor.
@@ -69,6 +89,7 @@ fn token_nuevo() -> Result<String, String> {
 
 struct Instancia {
     pid: i32,
+    puerto: u16,
     url: String,
 }
 
@@ -83,6 +104,24 @@ impl Servidor {
         }
     }
 
+    /// Si el puerto lo ocupa el servidor que arrancamos nosotros.
+    ///
+    /// La versión anterior solo comprobaba que *algo* aceptara TCP en el
+    /// 8000, así que un Django del usuario se abría en el navegador como si
+    /// fuera el analizador. Ahora se exige que sea nuestra instancia
+    /// registrada, que su proceso siga vivo y que el puerto siga aceptando.
+    pub fn es_nuestra_instancia(&self, puerto: u16) -> bool {
+        let guard = self.instancia.lock().unwrap();
+        match guard.as_ref() {
+            Some(inst) => {
+                inst.puerto == puerto
+                    && unsafe { libc::kill(inst.pid, 0) } == 0
+                    && acepta(puerto)
+            }
+            None => false,
+        }
+    }
+
     /// Deja listo el analizador web y entrega por `al_terminar` la URL que hay
     /// que abrir.
     ///
@@ -92,29 +131,24 @@ impl Servidor {
     where
         F: FnOnce(Result<String, String>) + Send + 'static,
     {
-        // Ya teníamos uno vivo: se reutiliza con su token, en vez de arrancar
-        // un segundo que chocaría en el mismo puerto.
+        // Ya teníamos uno vivo y sigue siendo el nuestro: se reutiliza con su
+        // token, en vez de arrancar un segundo servidor. Si el puerto lo
+        // ocupa ahora otra cosa (o nuestro proceso ya murió), no se reutiliza
+        // nada: se arranca uno nuevo más abajo, en un puerto libre.
         {
-            let guard = self.instancia.lock().unwrap();
-            if let Some(inst) = guard.as_ref() {
-                if puerto_ocupado() {
-                    al_terminar(Ok(inst.url.clone()));
+            let existente = {
+                let guard = self.instancia.lock().unwrap();
+                guard.as_ref().map(|inst| (inst.puerto, inst.url.clone()))
+            };
+            if let Some((puerto, url)) = existente {
+                if self.es_nuestra_instancia(puerto) {
+                    al_terminar(Ok(url));
                     return;
                 }
             }
         }
 
-        // El puerto está ocupado por algo que no es nuestro: puede ser un
-        // `make web` del propio usuario. No conocemos su token, así que se
-        // abre la URL a secas y que la sesión del navegador haga el resto.
-        if puerto_ocupado() {
-            al_terminar(Ok(format!("http://{HOST}:{PUERTO}/")));
-            return;
-        }
-
-        // Sin motor empaquetado no hay servidor que arrancar. No es
-        // necesariamente un error: puede haber un `make web` del usuario que
-        // ya se habría atendido arriba.
+        // Sin motor empaquetado no hay servidor que arrancar.
         let Some(motor) = motor else {
             al_terminar(Err(
                 "no hay servidor que abrir: falta el motor empaquetado".to_string()
@@ -122,6 +156,13 @@ impl Servidor {
             return;
         };
 
+        let puerto = match puerto_libre() {
+            Ok(p) => p,
+            Err(e) => {
+                al_terminar(Err(e));
+                return;
+            }
+        };
         let token = match token_nuevo() {
             Ok(t) => t,
             Err(e) => {
@@ -141,7 +182,7 @@ impl Servidor {
             .arg("--host")
             .arg(HOST)
             .arg("--port")
-            .arg(PUERTO.to_string())
+            .arg(puerto.to_string())
             .env("DISK_ANALYZER_TOKEN", &token)
             .stdin(Stdio::null())
             .stdout(Stdio::null())
@@ -159,9 +200,10 @@ impl Servidor {
             }
         };
         let pid = child.id() as i32;
-        let url = format!("http://{HOST}:{PUERTO}/?token={token}");
+        let url = format!("http://{HOST}:{puerto}/?token={token}");
         *self.instancia.lock().unwrap() = Some(Instancia {
             pid,
+            puerto,
             url: url.clone(),
         });
 
@@ -169,7 +211,7 @@ impl Servidor {
         std::thread::spawn(move || {
             let limite = Instant::now() + ARRANQUE_MAXIMO;
             while Instant::now() < limite {
-                if puerto_ocupado() {
+                if acepta(puerto) {
                     al_terminar(Ok(url));
                     return;
                 }
@@ -193,7 +235,7 @@ impl Servidor {
     }
 
     /// Al salir de la app. Igual que con el análisis: lo que arrancamos
-    /// nosotros no debe sobrevivirnos ocupando el puerto 8000.
+    /// nosotros no debe sobrevivirnos ocupando el puerto que tomó.
     pub fn kill_blocking(&self) {
         let inst = self.instancia.lock().unwrap().take();
         if let Some(inst) = inst {
@@ -205,5 +247,40 @@ impl Servidor {
 impl Default for Servidor {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn pide_un_puerto_libre_distinto_del_8000() {
+        let p = puerto_libre().expect("debería conseguir un puerto");
+        assert_ne!(p, 8000, "el 8000 está muy disputado: Django, Rails, etc.");
+        assert!(p >= 1024, "no se piden puertos privilegiados");
+    }
+
+    #[test]
+    fn dos_llamadas_no_devuelven_el_mismo_puerto_ocupado() {
+        let a = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let ocupado = a.local_addr().unwrap().port();
+        // Mientras `a` siga vivo, nadie debe proponer ese puerto.
+        for _ in 0..20 {
+            assert_ne!(puerto_libre().unwrap(), ocupado);
+        }
+    }
+
+    #[test]
+    fn no_reutiliza_un_servidor_ajeno() {
+        // Alguien ocupa un puerto sin ser nuestro servidor.
+        let ajeno = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let puerto = ajeno.local_addr().unwrap().port();
+        let servidor = Servidor::new();
+        assert!(
+            !servidor.es_nuestra_instancia(puerto),
+            "abrir el navegador en un servidor ajeno lo presenta como nuestro"
+        );
     }
 }

--- a/desktop/src-tauri/src/servidor.rs
+++ b/desktop/src-tauri/src/servidor.rs
@@ -192,7 +192,7 @@ impl Servidor {
             // ocupando el puerto.
             .process_group(0);
 
-        let child = match cmd.spawn() {
+        let mut child = match cmd.spawn() {
             Ok(c) => c,
             Err(e) => {
                 al_terminar(Err(format!("no se pudo arrancar el servidor: {e}")));
@@ -205,6 +205,27 @@ impl Servidor {
             pid,
             puerto,
             url: url.clone(),
+        });
+
+        // Reap the child. `Command::spawn()` hands back a `Child` that, if
+        // just dropped, leaves the process a zombie once it dies -- and
+        // `libc::kill(pid, 0)` keeps returning 0 ("exists") for a zombie
+        // forever, because the kernel keeps its PID entry until someone
+        // calls wait() on it. `es_nuestra_instancia` relies on that same
+        // `kill(pid, 0)` to tell a live server of ours from a dead one; with
+        // a permanent zombie the pid check can never fail, so the whole
+        // function degrades to "does something accept connections on this
+        // port" -- exactly the bug the port-reuse fix was supposed to close.
+        // Worse: if that port is later reused by an unrelated process, we'd
+        // hand the browser that stranger's page with our token in the URL.
+        //
+        // Same pattern as analisis.rs's scan-runner thread: `child` is
+        // moved into a dedicated thread that owns it exclusively and blocks
+        // on `wait()` for as long as the server lives. This doesn't block
+        // `abrir()`'s caller -- it's a fire-and-forget reaper, not on the
+        // startup-polling path below.
+        std::thread::spawn(move || {
+            let _ = child.wait();
         });
 
         let servidor = Arc::clone(self);
@@ -273,14 +294,60 @@ mod tests {
     }
 
     #[test]
-    fn no_reutiliza_un_servidor_ajeno() {
-        // Alguien ocupa un puerto sin ser nuestro servidor.
+    fn no_reutiliza_un_servidor_ajeno_con_una_instancia_de_verdad_registrada() {
+        // Antes esta prueba construía `Servidor::new()` con `instancia: None`,
+        // así que salía por el brazo `None => false` de `es_nuestra_instancia`
+        // sin llegar nunca a mirar el pid -- vacua: pasaba igual aunque la
+        // rama `Some(inst)` tuviera cualquier bug.
+        //
+        // El único llamante real (`abrir`) siempre pasa el puerto que YA
+        // tiene guardado en `self.instancia`, así que en producción
+        // `inst.puerto == puerto` es tautológicamente cierto y lo único que
+        // de verdad distingue "es nuestro servidor" de "es un ajeno que
+        // ocupa el mismo puerto" es la comprobación de pid -- exactamente lo
+        // que el hallazgo de la revisión señala: sin reap, esa comprobación
+        // nunca falla, y la función se reduce a "¿algo acepta conexiones
+        // aquí?".
+        //
+        // Para ejercer esa rama de verdad, se registra una `Instancia` con
+        // un pid que perteneció a un proceso real y ya terminó -- se lanza,
+        // se espera con `wait()` (reap explícito, ver comentario del fix en
+        // `abrir`) y se usa ESE pid, no uno inventado que nunca existió.
+        // Con el pid genuinamente muerto, `libc::kill(pid, 0)` devuelve
+        // ESRCH y la rama Some(inst) tiene que rechazarlo aunque el puerto
+        // registrado coincida con el de un servidor ajeno que sí acepta
+        // conexiones.
+        //
+        // Nota sobre "zombi": un proceso zombi de verdad (terminado pero
+        // SIN reap) sigue respondiendo 0 a `kill(pid, 0)` -- es justamente
+        // el bug que este mismo commit arregla, verificado en
+        // /tmp/zombie_test.py durante el diagnóstico. Por eso esta prueba
+        // usa un pid ya reaped (el estado en el que queda un pid nuestro
+        // DESPUÉS del fix, una vez el hilo dedicado le hace `wait()`) en vez
+        // de un zombi real sin reap: probar con un zombi real solo
+        // confirmaría el bug, no la corrección.
+        let mut hijo = Command::new("true")
+            .spawn()
+            .expect("no se pudo lanzar un proceso de prueba");
+        let pid_ya_muerto = hijo.id() as i32;
+        hijo.wait().expect("no se pudo esperar al proceso de prueba");
+
+        // Alguien más ocupa, ahora mismo, el mismo puerto que registramos
+        // como si fuera el nuestro.
         let ajeno = TcpListener::bind(("127.0.0.1", 0)).unwrap();
         let puerto = ajeno.local_addr().unwrap().port();
+
         let servidor = Servidor::new();
+        *servidor.instancia.lock().unwrap() = Some(Instancia {
+            pid: pid_ya_muerto,
+            puerto,
+            url: format!("http://{HOST}:{puerto}/?token=lo-que-sea"),
+        });
+
         assert!(
             !servidor.es_nuestra_instancia(puerto),
-            "abrir el navegador en un servidor ajeno lo presenta como nuestro"
+            "abrir el navegador en un servidor ajeno lo presenta como nuestro, \
+             aunque el pid registrado ya no exista"
         );
     }
 }

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -895,169 +895,29 @@ class DiskAnalyzer:
         return smart_recs
 
     def generate_recommendations(self) -> List[Dict]:
-        """Genera recomendaciones agrupadas por nivel de agresividad.
-        Cada recomendación tiene un 'tier' (1-4) de conservador a agresivo."""
-        recommendations = []
+        """Delegado en el motor compartido (disk_analyzer_core.DiskAnalyzerCore).
 
-        # ── TIER 1: Seguro (auto-limpiable, sin revisión) ──
-        # Logs del sistema
-        log_locs = [l for l in self.cache_locations if l['type'] == cache_types.LOGS]
-        if log_locs:
-            size = sum(l['size'] for l in log_locs)
-            if size > 10 * MB:
-                recommendations.append({
-                    'tier': 1, 'priority': 'Seguro',
-                    'type': cache_types.LOGS,
-                    'description': f'{self.format_size(size)} en logs del sistema',
-                    'space': size,
-                    'command': comandos.borrar_contenido([l['path'] for l in log_locs])
-                })
+        Antes habia aqui una segunda implementacion de los mismos niveles,
+        que ya habia divergido de la del core: la web recomendaba una cosa y
+        la app de bandeja otra sobre el mismo disco, porque la app de bandeja
+        ejecuta este fichero (ver desktop/src-tauri/src/analisis.rs), no el
+        core. Las cuatro reglas que solo existian aqui (Xcode DerivedData,
+        Runtimes de Simuladores, Maquinas Virtuales, y la variante de Cache
+        de Simuladores) se movieron a disk_analyzer_core.py para que ninguna
+        interfaz pierda recomendaciones.
 
-        # Homebrew caches
-        brew_files = [f for f in self.large_files if 'Homebrew/downloads' in f['path']]
-        if brew_files:
-            size = sum(f['size'] for f in brew_files)
-            recommendations.append({
-                'tier': 1, 'priority': 'Seguro',
-                'type': 'Cache de Homebrew',
-                'description': f'{len(brew_files)} descargas de Homebrew ({self.format_size(size)})',
-                'space': size,
-                'command': 'brew cleanup --prune=all'
-            })
+        detect_smart_recommendations() sigue siendo una fuente propia de la
+        CLI/app de bandeja (patrones avanzados: entornos conda, node_modules
+        huerfanos, etc.) y se anade encima, tal y como hacia el codigo
+        anterior.
+        """
+        from disk_analyzer_core import DiskAnalyzerCore
+        prestado = DiskAnalyzerCore(str(self.start_path))
+        prestado.cache_locations = self.cache_locations
+        prestado.large_files = self.large_files
+        prestado.docker_stats = self.docker_stats
+        recommendations = prestado.generate_recommendations()
 
-        # VS Code caches
-        vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
-        if vscode_locs:
-            size = sum(l['size'] for l in vscode_locs)
-            if size > 10 * MB:
-                recommendations.append({
-                    'tier': 1, 'priority': 'Seguro',
-                    'type': 'Cache de VS Code',
-                    'description': f'{self.format_size(size)} en cache de VS Code',
-                    'space': size,
-                    'command': comandos.borrar_contenido([l['path'] for l in vscode_locs])
-                })
-
-        # npm cache
-        npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
-        if npm_locs:
-            size = sum(l['size'] for l in npm_locs)
-            if size > 50 * MB:
-                recommendations.append({
-                    'tier': 1, 'priority': 'Seguro',
-                    'type': 'Cache de npm',
-                    'description': f'{self.format_size(size)} en cache de npm (se regenera con npm install)',
-                    'space': size,
-                    'command': 'npm cache clean --force'
-                })
-
-        # ── TIER 2: Moderado (requiere revisión rápida) ──
-        # Simulator caches
-        sim_files = [f for f in self.large_files
-                     if 'CoreSimulator' in f['path'] and not self.is_protected_path(f['path'])]
-        if sim_files:
-            size = sum(f['size'] for f in sim_files)
-            recommendations.append({
-                'tier': 2, 'priority': 'Moderado',
-                'type': 'Cache de Simuladores iOS',
-                'description': f'{len(sim_files)} archivos de cache de simuladores ({self.format_size(size)})',
-                'space': size,
-                'command': 'xcrun simctl delete unavailable && rm -rf ~/Library/Developer/CoreSimulator/Caches/'
-            })
-
-        # Old downloads
-        old_downloads = [f for f in self.large_files
-                         if '/Downloads/' in f['path'] and f['age_days'] > 30]
-        if old_downloads:
-            size = sum(f['size'] for f in old_downloads)
-            recommendations.append({
-                'tier': 2, 'priority': 'Moderado',
-                'type': 'Descargas Antiguas',
-                'description': f'{len(old_downloads)} archivos en Downloads con más de 30 días ({self.format_size(size)})',
-                'space': size,
-                'command': f"find ~/Downloads -mtime +30 -size +{int(self.min_size/MB)}M -type f -ls"
-            })
-
-        # Docker
-        if self.docker_stats and self.docker_stats['available'] and self.docker_stats['reclaimable'] > 100 * MB:
-            recommendations.append({
-                'tier': 2, 'priority': 'Moderado',
-                'type': 'Docker',
-                'description': f'Docker: {self.format_size(self.docker_stats["reclaimable"])} recuperable de {self.format_size(self.docker_stats["total_size"])} total',
-                'space': self.docker_stats['reclaimable'],
-                'command': 'docker system prune -a -f'
-            })
-
-        # ── TIER 3: Agresivo (puede requerir re-descargas) ──
-        # ~/.cache (huggingface, pip, etc.)
-        cache_general = [l for l in self.cache_locations
-                         if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
-        if cache_general:
-            size = sum(l['size'] for l in cache_general)
-            if size > 100 * MB:
-                recommendations.append({
-                    'tier': 3, 'priority': 'Agresivo',
-                    'type': 'Cache General (~/.cache)',
-                    'description': f'{self.format_size(size)} en ~/.cache (modelos ML, pip, etc. — se re-descargan)',
-                    'space': size,
-                    'command': 'du -sh ~/.cache/*/ | sort -hr | head -20'
-                })
-
-        # Xcode DerivedData
-        xcode_locs = [l for l in self.cache_locations if l['type'] == cache_types.XCODE]
-        if xcode_locs:
-            size = sum(l['size'] for l in xcode_locs)
-            if size > 100 * MB:
-                recommendations.append({
-                    'tier': 3, 'priority': 'Agresivo',
-                    'type': 'Xcode DerivedData',
-                    'description': f'{self.format_size(size)} en datos de compilación (se regeneran al compilar)',
-                    'space': size,
-                    'command': 'rm -rf ~/Library/Developer/Xcode/DerivedData/*'
-                })
-
-        # Old Simulator runtimes (the protected DMGs — user can remove via Xcode)
-        sim_runtimes = [f for f in self.large_files
-                        if 'iOSSimulatorRuntime' in f['path'] or 'SimRuntime' in f['path']]
-        if sim_runtimes:
-            size = sum(f['size'] for f in sim_runtimes)
-            if size > 1 * GB:
-                recommendations.append({
-                    'tier': 3, 'priority': 'Agresivo',
-                    'type': 'Runtimes de Simuladores',
-                    'description': f'{self.format_size(size)} en runtimes de iOS Simulator (eliminar desde Xcode > Settings > Platforms)',
-                    'space': size,
-                    'command': 'xcrun simctl runtime list'
-                })
-
-        # ── TIER 4: Máximo (requiere decisiones del usuario) ──
-        # Large files > 1GB that are not protected
-        huge_deletable = [f for f in self.large_files
-                          if f['size'] > GB and not self.is_protected_path(f['path'])]
-        if huge_deletable:
-            size = sum(f['size'] for f in huge_deletable)
-            recommendations.append({
-                'tier': 4, 'priority': 'Máximo',
-                'type': 'Archivos Gigantes',
-                'description': f'{len(huge_deletable)} archivos de más de 1GB que puedes revisar ({self.format_size(size)})',
-                'space': size,
-                'command': '# Revisa la tabla de archivos grandes arriba'
-            })
-
-        # VMs
-        dev_files = [f for f in self.large_files
-                     if any(ext in f['extension'] for ext in ['.vmdk', '.vdi', '.qcow2'])]
-        if dev_files:
-            size = sum(f['size'] for f in dev_files)
-            recommendations.append({
-                'tier': 4, 'priority': 'Máximo',
-                'type': 'Máquinas Virtuales',
-                'description': f'{len(dev_files)} archivos de VMs ({self.format_size(size)})',
-                'space': size,
-                'command': 'find / -name "*.vmdk" -o -name "*.vdi" -o -name "*.qcow2" 2>/dev/null | head -20'
-            })
-
-        # -- Recomendaciones inteligentes --
         recommendations.extend(self.detect_smart_recommendations())
 
         return sorted(recommendations, key=lambda x: (x['tier'], -x['space']))

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -916,6 +916,11 @@ class DiskAnalyzer:
         prestado.cache_locations = self.cache_locations
         prestado.large_files = self.large_files
         prestado.docker_stats = self.docker_stats
+        # Both classes name this attribute the same (self.min_size, bytes);
+        # propagate it so the shared Descargas Antiguas rule respects the
+        # size floor the CLI user configured, instead of always falling back
+        # to the core's own default.
+        prestado.min_size = self.min_size
         recommendations = prestado.generate_recommendations()
 
         recommendations.extend(self.detect_smart_recommendations())

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -714,6 +714,7 @@ class DiskAnalyzer:
                     if has_stale and size > 0:
                         smart_recs.append({
                             'tier': 2, 'priority': 'Moderado',
+                            'id': 'conda_obsoleto',
                             'type': 'Entorno Conda Obsoleto',
                             'description': (
                                 f'Entorno conda "{env_name}" sin actividad reciente '
@@ -751,6 +752,7 @@ class DiskAnalyzer:
                 if stale and size > 0:
                     smart_recs.append({
                         'tier': 2, 'priority': 'Moderado',
+                        'id': 'node_modules_huerfano',
                         'type': 'node_modules Huerfano',
                         'description': (
                             f'node_modules sin actividad de proyecto en 60+ dias '
@@ -776,6 +778,7 @@ class DiskAnalyzer:
                 total = homebrew_python_size + anaconda_python_size
                 smart_recs.append({
                     'tier': 3, 'priority': 'Agresivo',
+                    'id': 'python_multiple',
                     'type': 'Multiples Instalaciones Python',
                     'description': (
                         f'Se detectaron instalaciones de Python tanto en Homebrew '
@@ -806,6 +809,7 @@ class DiskAnalyzer:
                 repo_name = os.path.basename(repo_path)
                 smart_recs.append({
                     'tier': 2, 'priority': 'Moderado',
+                    'id': 'git_pack_files',
                     'type': 'Git Pack Files Grandes',
                     'description': (
                         f'Repositorio "{repo_name}" tiene pack files de '
@@ -845,6 +849,7 @@ class DiskAnalyzer:
                         )
                         smart_recs.append({
                             'tier': 3, 'priority': 'Agresivo',
+                            'id': 'time_machine_snapshots',
                             'type': 'Snapshots Locales de Time Machine',
                             'description': (
                                 f'{len(snapshot_dates)} snapshot(s) local(es) de Time Machine. '
@@ -880,6 +885,7 @@ class DiskAnalyzer:
             if archives_size > 1 * GB:
                 smart_recs.append({
                     'tier': 3, 'priority': 'Agresivo',
+                    'id': 'xcode_archives_antiguos',
                     'type': 'Xcode Archives Antiguos',
                     'description': (
                         f'{self.format_size(archives_size)} en Xcode Archives. '

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -26,6 +26,7 @@ from analyzer.constants import (
 from analyzer import protection
 from analyzer import cache_types
 from analyzer import measurement
+from analyzer import comandos
 
 class DiskAnalyzer:
     def __init__(self, start_path: str, min_size_mb: float = 10):
@@ -755,7 +756,7 @@ class DiskAnalyzer:
                             f'({self.format_size(size)}) en {parent}'
                         ),
                         'space': size,
-                        'command': f"rm -rf '{dir_path}'",
+                        'command': comandos.borrar_rutas([dir_path]),
                     })
         except Exception:
             pass
@@ -878,7 +879,7 @@ class DiskAnalyzer:
                         f'Los archivos se pueden eliminar si ya no necesitas distribuir esas builds.'
                     ),
                     'space': archives_size,
-                    'command': f"rm -rf '{xcode_archives_path}'/*",
+                    'command': comandos.borrar_contenido([xcode_archives_path]),
                 })
         except Exception:
             pass
@@ -901,7 +902,7 @@ class DiskAnalyzer:
                     'type': cache_types.LOGS,
                     'description': f'{self.format_size(size)} en logs del sistema',
                     'space': size,
-                    'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)
+                    'command': comandos.borrar_contenido([l['path'] for l in log_locs])
                 })
 
         # Homebrew caches
@@ -926,7 +927,7 @@ class DiskAnalyzer:
                     'type': 'Cache de VS Code',
                     'description': f'{self.format_size(size)} en cache de VS Code',
                     'space': size,
-                    'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in vscode_locs)
+                    'command': comandos.borrar_contenido([l['path'] for l in vscode_locs])
                 })
 
         # npm cache

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -1351,7 +1351,7 @@ class DiskAnalyzer:
         if cache_files:
             print(f"\n   # Limpiar archivos de cache grandes ({len(cache_files)} archivos)")
             for f in cache_files[:5]:
-                print(f"   rm -f '{f['path']}'")
+                print(f"   rm -f {comandos.escapar(f['path'])}")
             if len(cache_files) > 5:
                 print(f"   # ... y {len(cache_files) - 5} archivos más de cache")
         

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -720,7 +720,7 @@ class DiskAnalyzer:
                                 f'({self.format_size(size)})'
                             ),
                             'space': size,
-                            'command': f'conda env remove -n {env_name}',
+                            'command': f'conda env remove -n {comandos.escapar(env_name)}',
                         })
         except Exception:
             pass
@@ -810,7 +810,7 @@ class DiskAnalyzer:
                         f'Ejecuta gc para compactar.'
                     ),
                     'space': total_pack,
-                    'command': f"cd '{repo_path}' && git gc --aggressive",
+                    'command': f'cd {comandos.escapar(repo_path)} && git gc --aggressive',
                 })
         except Exception:
             pass
@@ -3971,7 +3971,7 @@ class DiskAnalyzer:
                         continue
                     commands.append({
                         'description': f'Revisar directorio grande: {dir_name}',
-                        'command': f'du -sh "{path}"/* | sort -hr | head -20',
+                        'command': f'du -sh {comandos.escapar(path)}/* | sort -hr | head -20',
                         'risk': 'N/A',
                         'space_estimate': self.format_size(size)
                     })

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -4388,14 +4388,27 @@ class DiskAnalyzer:
             print("\n🔍 SIMULACIÓN DE LIMPIEZA (dry-run):")
         else:
             print("\n🧹 LIMPIANDO ARCHIVOS DE CACHE:")
-        
+
         total_cleaned = 0
-        
+
         for cache_loc in self.cache_locations:
             path = Path(cache_loc['path'])
-            
+
             # Solo limpiar caches seguros — NUNCA Downloads ni Cache General
             safe_to_clean = cache_loc['type'] in cache_types.SAFE_TO_CLEAN
+
+            # La verja: aunque el type clasifique la ruta como "segura", no se
+            # borra nada que protection.puede_borrarse rechace. Es la misma
+            # verja que instala analyzer/comandos.py para todo comando
+            # generado -- este método no pasa por comandos.py (borra
+            # directamente con unlink()/rglob()), así que sin esta llamada
+            # queda fuera de la verja. Sin ella, un usuario cuyo nombre
+            # contiene una subcadena que cache_types.classify() reconoce (p.
+            # ej. 'logan' -> 'log') podía ver ~/Downloads clasificado como un
+            # tipo seguro y borrado permanentemente.
+            if safe_to_clean and not protection.puede_borrarse(str(path)):
+                print(f"   ⚠️  Omitido (protegido): {cache_loc['type']} - {path}")
+                safe_to_clean = False
 
             if safe_to_clean and path.exists():
                 if dry_run:

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -721,6 +721,7 @@ class DiskAnalyzer:
                             ),
                             'space': size,
                             'command': f'conda env remove -n {comandos.escapar(env_name)}',
+                            'efecto': 'irreversible',
                         })
         except Exception:
             pass
@@ -757,6 +758,7 @@ class DiskAnalyzer:
                         ),
                         'space': size,
                         'command': comandos.borrar_rutas([dir_path]),
+                        'efecto': 'borra',
                     })
         except Exception:
             pass
@@ -787,6 +789,7 @@ class DiskAnalyzer:
                         '#   brew uninstall python  # si usas Anaconda\n'
                         '#   conda deactivate && rm -rf ~/anaconda3  # si usas Homebrew'
                     ),
+                    'efecto': 'solo_lista',
                 })
         except Exception:
             pass
@@ -811,6 +814,7 @@ class DiskAnalyzer:
                     ),
                     'space': total_pack,
                     'command': f'cd {comandos.escapar(repo_path)} && git gc --aggressive',
+                    'efecto': 'irreversible',
                 })
         except Exception:
             pass
@@ -848,6 +852,7 @@ class DiskAnalyzer:
                             ),
                             'space': len(snapshot_dates) * GB,
                             'command': commands,
+                            'efecto': 'irreversible',
                         })
         except Exception:
             pass
@@ -880,6 +885,7 @@ class DiskAnalyzer:
                     ),
                     'space': archives_size,
                     'command': comandos.borrar_contenido([xcode_archives_path]),
+                    'efecto': 'borra',
                 })
         except Exception:
             pass

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -916,8 +916,15 @@ class DiskAnalyzer:
         CLI/app de bandeja (patrones avanzados: entornos conda, node_modules
         huerfanos, etc.) y se anade encima, tal y como hacia el codigo
         anterior.
+
+        prestado.generate_recommendations() ya descarta sus propias
+        recomendaciones con 'command' vacio (ver
+        descartar_recomendaciones_sin_comando en disk_analyzer_core.py), pero
+        detect_smart_recommendations() es una fuente propia de este fichero
+        que no pasa por ahi, asi que el filtro se reaplica despues de anexar
+        su salida.
         """
-        from disk_analyzer_core import DiskAnalyzerCore
+        from disk_analyzer_core import DiskAnalyzerCore, descartar_recomendaciones_sin_comando
         prestado = DiskAnalyzerCore(str(self.start_path))
         prestado.cache_locations = self.cache_locations
         prestado.large_files = self.large_files
@@ -930,6 +937,7 @@ class DiskAnalyzer:
         recommendations = prestado.generate_recommendations()
 
         recommendations.extend(self.detect_smart_recommendations())
+        recommendations = descartar_recomendaciones_sin_comando(recommendations)
 
         return sorted(recommendations, key=lambda x: (x['tier'], -x['space']))
 

--- a/disk_analyzer.py
+++ b/disk_analyzer.py
@@ -847,10 +847,12 @@ class DiskAnalyzer:
                             'tier': 3, 'priority': 'Agresivo',
                             'type': 'Snapshots Locales de Time Machine',
                             'description': (
-                                f'{len(snapshot_dates)} snapshot(s) local(es) de Time Machine '
-                                f'detectados. Pueden ocupar varios GB.'
+                                f'{len(snapshot_dates)} snapshot(s) local(es) de Time Machine. '
+                                f'macOS no expone cuánto ocupan: pueden ir de unos megas a '
+                                f'varios GB según lo que haya cambiado en el disco. '
+                                f'El comando pide privilegios de administrador (sudo).'
                             ),
-                            'space': len(snapshot_dates) * GB,
+                            'space': 0,  # macOS no expone el tamaño real; no inventamos GB
                             'command': commands,
                             'efecto': 'irreversible',
                         })

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -569,27 +569,31 @@ class DiskAnalyzerCore:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
                 'description': f'{self.format_size(sum(l["size"] for l in log_locs))} en logs',
                 'space': sum(l['size'] for l in log_locs),
-                'command': comandos.borrar_contenido([l['path'] for l in log_locs])})
+                'command': comandos.borrar_contenido([l['path'] for l in log_locs]),
+                'efecto': 'borra'})
 
         brew_files = [f for f in self.large_files if 'Homebrew/downloads' in f['path']]
         if brew_files:
             size = sum(f['size'] for f in brew_files)
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de Homebrew',
                 'description': f'{len(brew_files)} descargas ({self.format_size(size)})',
-                'space': size, 'command': 'brew cleanup --prune=all'})
+                'space': size, 'command': 'brew cleanup --prune=all',
+                'efecto': 'irreversible'})
 
         vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
         if vscode_locs and sum(l['size'] for l in vscode_locs) > 10 * MB:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
                 'description': f'{self.format_size(sum(l["size"] for l in vscode_locs))} en cache',
                 'space': sum(l['size'] for l in vscode_locs),
-                'command': comandos.borrar_contenido([l['path'] for l in vscode_locs])})
+                'command': comandos.borrar_contenido([l['path'] for l in vscode_locs]),
+                'efecto': 'borra'})
 
         npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
                 'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache',
-                'space': sum(l['size'] for l in npm_locs), 'command': 'npm cache clean --force'})
+                'space': sum(l['size'] for l in npm_locs), 'command': 'npm cache clean --force',
+                'efecto': 'irreversible'})
 
         # TIER 2: Moderado
         sim_files = [f for f in self.large_files
@@ -598,19 +602,22 @@ class DiskAnalyzerCore:
             recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Cache de Simuladores',
                 'description': f'{len(sim_files)} archivos ({self.format_size(sum(f["size"] for f in sim_files))})',
                 'space': sum(f['size'] for f in sim_files),
-                'command': 'xcrun simctl delete unavailable && rm -rf ~/Library/Developer/CoreSimulator/Caches/'})
+                'command': 'xcrun simctl delete unavailable && rm -rf ~/Library/Developer/CoreSimulator/Caches/',
+                'efecto': 'irreversible'})
 
         old_downloads = [f for f in self.large_files if '/Downloads/' in f['path'] and f['age_days'] > 30]
         if old_downloads:
             size = sum(f['size'] for f in old_downloads)
             recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Descargas Antiguas',
                 'description': f'{len(old_downloads)} archivos ({self.format_size(size)})',
-                'space': size, 'command': 'find ~/Downloads -mtime +30 -type f -ls'})
+                'space': size, 'command': 'find ~/Downloads -mtime +30 -type f -ls',
+                'efecto': 'solo_lista'})
 
         if self.docker_stats and self.docker_stats['available'] and self.docker_stats['reclaimable'] > 100 * MB:
             recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Docker',
                 'description': f'{self.format_size(self.docker_stats["reclaimable"])} recuperable',
-                'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f'})
+                'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f',
+                'efecto': 'irreversible'})
 
         # TIER 3: Agresivo
         cache_general = [l for l in self.cache_locations if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
@@ -618,14 +625,16 @@ class DiskAnalyzerCore:
             recommendations.append({'tier': 3, 'priority': 'Agresivo', 'type': 'Cache General (~/.cache)',
                 'description': f'{self.format_size(sum(l["size"] for l in cache_general))} (modelos ML, pip, etc.)',
                 'space': sum(l['size'] for l in cache_general),
-                'command': 'du -sh ~/.cache/*/ | sort -hr | head -20'})
+                'command': 'du -sh ~/.cache/*/ | sort -hr | head -20',
+                'efecto': 'solo_lista'})
 
         # TIER 4: Máximo
         huge = [f for f in self.large_files if f['size'] > GB and not self.is_protected_path(f['path'])]
         if huge:
             recommendations.append({'tier': 4, 'priority': 'Máximo', 'type': 'Archivos Gigantes',
                 'description': f'{len(huge)} archivos > 1GB ({self.format_size(sum(f["size"] for f in huge))})',
-                'space': sum(f['size'] for f in huge), 'command': '# Revisa la lista de archivos grandes'})
+                'space': sum(f['size'] for f in huge), 'command': '# Revisa la lista de archivos grandes',
+                'efecto': 'solo_lista'})
 
         return sorted(recommendations, key=lambda x: (x['tier'], -x['space']))
     

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -609,7 +609,24 @@ class DiskAnalyzerCore:
         recommendations = []
 
         # TIER 1: Seguro
-        log_locs = [l for l in self.cache_locations if l['type'] == cache_types.LOGS]
+        #
+        # The four rules below (logs, vscode, npm, papelera) are scoped by
+        # path as well as by `type`, matching the norm the app-caches rule
+        # (further down) and xcode_deriveddata already follow: never filter
+        # cache_locations by `type` alone. This is the same root cause as
+        # cache_types.classify() matching a username substring (Task 1 of
+        # this cleanup pass, see analyzer/cache_types.py) -- classify() is
+        # fixed now, but these four rules relied on it being right with no
+        # second check of their own. Before that fix, a home directory
+        # containing 'code' (e.g. '/Users/nicode') made classify() label
+        # ~/Library/Caches as VSCODE instead of GENERAL: the 21 GB there
+        # would then be picked up by this tier-1 'vscode' rule (unreviewed,
+        # described as "se regenera automáticamente") instead of the tier-2
+        # 'caches_de_apps' rule that's actually scoped to 'Library/Caches'.
+        # Scoping these four by path too means a future classify() bug can't
+        # repeat that escalation on its own.
+        log_locs = [l for l in self.cache_locations
+                    if l['type'] == cache_types.LOGS and 'Library/Logs' in l['path']]
         if log_locs and sum(l['size'] for l in log_locs) > 10 * MB:
             recommendations.append({'id': 'logs', 'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
                 'description': f'{self.format_size(sum(l["size"] for l in log_locs))} en logs',
@@ -625,7 +642,9 @@ class DiskAnalyzerCore:
                 'space': size, 'command': 'brew cleanup --prune=all',
                 'efecto': 'irreversible'})
 
-        vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
+        vscode_locs = [l for l in self.cache_locations
+                       if l['type'] == cache_types.VSCODE
+                       and ('Application Support/Code' in l['path'] or 'AppData/Roaming/Code' in l['path'])]
         if vscode_locs and sum(l['size'] for l in vscode_locs) > 10 * MB:
             recommendations.append({'id': 'vscode', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
                 'description': f'{self.format_size(sum(l["size"] for l in vscode_locs))} en cache',
@@ -633,7 +652,8 @@ class DiskAnalyzerCore:
                 'command': comandos.borrar_contenido([l['path'] for l in vscode_locs]),
                 'efecto': 'borra'})
 
-        npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
+        npm_locs = [l for l in self.cache_locations
+                    if l['type'] == cache_types.NPM and '/.npm' in l['path']]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:
             recommendations.append({'id': 'npm', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
                 'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache de npm (se regenera con npm install)',
@@ -643,7 +663,10 @@ class DiskAnalyzerCore:
         # La papelera: espacio que el usuario ya decidió tirar. Nivel 1 sin
         # discusión, y además es lo único que hace que "mover a la papelera"
         # libere algo de verdad en el mismo volumen.
-        papelera = [l for l in self.cache_locations if l['type'] == cache_types.TRASH]
+        papelera = [l for l in self.cache_locations
+                    if l['type'] == cache_types.TRASH
+                    and ('.Trash' in l['path'] or 'RECYCLE.BIN' in l['path']
+                         or '.local/share/Trash' in l['path'])]
         if papelera and sum(l['size'] for l in papelera) > 100 * MB:
             total = sum(l['size'] for l in papelera)
             recommendations.append({'id': 'papelera', 'tier': 1, 'priority': 'Seguro', 'type': cache_types.TRASH,

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -32,7 +32,11 @@ class DiskAnalyzerCore:
     def __init__(self, start_path: str, min_size_mb: float = 10, 
                  progress_callback: Optional[Callable] = None):
         self.start_path = Path(start_path).expanduser()
-        self.min_size = min_size_mb * MB
+        # Floor at 1 MB, matching disk_analyzer.DiskAnalyzer -- a min_size
+        # of 0 would treat every file as "large" and also produces a
+        # nonsensical 'find ... -size +0M' filter in the Descargas Antiguas
+        # command (matches everything, defeating the point of the filter).
+        self.min_size = max(min_size_mb, 1) * MB
         self.total_scanned = 0
         self.errors = []
         self.cache_locations = []
@@ -605,7 +609,7 @@ class DiskAnalyzerCore:
         npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:
             recommendations.append({'id': 'npm', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
-                'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache',
+                'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache de npm (se regenera con npm install)',
                 'space': sum(l['size'] for l in npm_locs), 'command': 'npm cache clean --force',
                 'efecto': 'irreversible'})
 
@@ -633,13 +637,13 @@ class DiskAnalyzerCore:
             # longer and less useful list than what the CLI used to show.
             min_size_mb = int(self.min_size / MB)
             recommendations.append({'id': 'descargas_antiguas', 'tier': 2, 'priority': 'Moderado', 'type': 'Descargas Antiguas',
-                'description': f'{len(old_downloads)} archivos ({self.format_size(size)})',
+                'description': f'{len(old_downloads)} archivos en Downloads con más de 30 días ({self.format_size(size)})',
                 'space': size, 'command': f'find ~/Downloads -mtime +30 -size +{min_size_mb}M -type f -ls',
                 'efecto': 'solo_lista'})
 
         if self.docker_stats and self.docker_stats['available'] and self.docker_stats['reclaimable'] > 100 * MB:
             recommendations.append({'id': 'docker', 'tier': 2, 'priority': 'Moderado', 'type': 'Docker',
-                'description': f'{self.format_size(self.docker_stats["reclaimable"])} recuperable',
+                'description': f'{self.format_size(self.docker_stats["reclaimable"])} recuperable de {self.format_size(self.docker_stats.get("total_size", 0))} total',
                 'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f',
                 'efecto': 'irreversible'})
 
@@ -647,7 +651,7 @@ class DiskAnalyzerCore:
         cache_general = [l for l in self.cache_locations if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
         if cache_general and sum(l['size'] for l in cache_general) > 100 * MB:
             recommendations.append({'id': 'cache_general', 'tier': 3, 'priority': 'Agresivo', 'type': 'Cache General (~/.cache)',
-                'description': f'{self.format_size(sum(l["size"] for l in cache_general))} (modelos ML, pip, etc.)',
+                'description': f'{self.format_size(sum(l["size"] for l in cache_general))} en ~/.cache (modelos ML, pip, etc. — se re-descargan)',
                 'space': sum(l['size'] for l in cache_general),
                 'command': 'du -sh ~/.cache/*/ | sort -hr | head -20',
                 'efecto': 'solo_lista'})
@@ -655,7 +659,23 @@ class DiskAnalyzerCore:
         # Moved here from the CLI-only copy of this method (it existed only
         # there, so it would have silently disappeared for web users -- and
         # from the menu-bar app too, once the CLI stopped duplicating it).
-        xcode_locs = [l for l in self.cache_locations if l['type'] == cache_types.XCODE]
+        #
+        # IMPORTANT: cache_types.XCODE covers BOTH
+        # ~/Library/Developer/Xcode/DerivedData AND .../Xcode/Archives
+        # (classify() matches on the substring 'xcode' anywhere in the path,
+        # see analyzer/cache_types.py). Archives hold signed builds and
+        # dSYMs needed to symbolicate crashes from already-shipped versions
+        # -- they do NOT regenerate on build, unlike DerivedData. Filtering
+        # cache_locations by type alone here would silently fold Archives
+        # into an 'efecto: borra' rule described as "se regeneran al
+        # compilar", which is false and irreversible for real archived
+        # builds. detect_smart_recommendations() already has an honest,
+        # size-gated rule for Archives ('Xcode Archives Antiguos', id
+        # 'xcode_archives_antiguos'), so this rule stays scoped to
+        # DerivedData only -- widening it to Archives would also
+        # double-count recoverable space against that other rule.
+        xcode_locs = [l for l in self.cache_locations
+                      if l['type'] == cache_types.XCODE and 'DerivedData' in l['path']]
         if xcode_locs and sum(l['size'] for l in xcode_locs) > 100 * MB:
             recommendations.append({'id': 'xcode_deriveddata', 'tier': 3, 'priority': 'Agresivo', 'type': 'Xcode DerivedData',
                 'description': f'{self.format_size(sum(l["size"] for l in xcode_locs))} en datos de compilación (se regeneran al compilar)',

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -24,6 +24,7 @@ from analyzer.constants import (
 from analyzer import protection
 from analyzer import cache_types
 from analyzer import measurement
+from analyzer import comandos
 
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""
@@ -568,7 +569,7 @@ class DiskAnalyzerCore:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
                 'description': f'{self.format_size(sum(l["size"] for l in log_locs))} en logs',
                 'space': sum(l['size'] for l in log_locs),
-                'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)})
+                'command': comandos.borrar_contenido([l['path'] for l in log_locs])})
 
         brew_files = [f for f in self.large_files if 'Homebrew/downloads' in f['path']]
         if brew_files:
@@ -582,7 +583,7 @@ class DiskAnalyzerCore:
             recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
                 'description': f'{self.format_size(sum(l["size"] for l in vscode_locs))} en cache',
                 'space': sum(l['size'] for l in vscode_locs),
-                'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in vscode_locs)})
+                'command': comandos.borrar_contenido([l['path'] for l in vscode_locs])})
 
         npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -26,6 +26,33 @@ from analyzer import cache_types
 from analyzer import measurement
 from analyzer import comandos
 
+
+def descartar_recomendaciones_sin_comando(recomendaciones: List[Dict]) -> List[Dict]:
+    """Descarta recomendaciones cuyo 'command' quedó vacío (o solo espacios).
+
+    Una recomendación con command vacío promete un espacio que no se puede
+    liberar: el botón que la ejecuta no hace nada. Esto pasa cuando
+    comandos.borrar_contenido/borrar_rutas descartan TODAS las rutas de una
+    regla porque ninguna pasa protection.puede_borrarse -- por ejemplo, si
+    una regla nueva apunta a una ubicación que protection.py todavía no
+    reconoce como segura (así se descubrió esta clase de fallo: Task 7,
+    con 'papelera' y 'xcode_archives_antiguos' antes de ampliar la
+    whitelist). Es una red de seguridad genérica: si la verja bloquea otra
+    ruta mañana, la recomendación desaparece por ausencia en vez de quedar
+    como un botón muerto que nadie nota.
+
+    Las recomendaciones 'solo_lista' llevan un comando real de inspección
+    (un `find`, un `du`, o un comentario de shell) como 'command', nunca la
+    cadena vacía, así que sobreviven: el filtro es literalmente sobre la
+    cadena vacía, no sobre qué tipo de comando es.
+
+    Usada por DiskAnalyzerCore.generate_recommendations() y por
+    DiskAnalyzer.generate_recommendations() (disk_analyzer.py), que la
+    reaplica después de anexar detect_smart_recommendations().
+    """
+    return [r for r in recomendaciones if (r.get('command') or '').strip()]
+
+
 class DiskAnalyzerCore:
     """Core disk analysis functionality with progress callback support"""
     
@@ -748,8 +775,9 @@ class DiskAnalyzerCore:
                 'command': 'find / -name "*.vmdk" -o -name "*.vdi" -o -name "*.qcow2" 2>/dev/null | head -20',
                 'efecto': 'solo_lista'})
 
+        recommendations = descartar_recomendaciones_sin_comando(recommendations)
         return sorted(recommendations, key=lambda x: (x['tier'], -x['space']))
-    
+
     def _get_cleanup_command_for_downloads(self) -> str:
         """Get platform-specific cleanup command for downloads"""
         if self.is_windows:

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -560,13 +560,27 @@ class DiskAnalyzerCore:
         }
     
     def generate_recommendations(self) -> List[Dict]:
-        """Genera recomendaciones agrupadas por nivel de agresividad (4 tiers)"""
+        """Genera recomendaciones agrupadas por nivel de agresividad (4 tiers).
+
+        This is the single source of these tiered rules. It used to be
+        duplicated in disk_analyzer.py (CLI + menu-bar app), and the two
+        copies had already drifted -- the web UI and the menu-bar app could
+        recommend different things for the same disk. disk_analyzer.py now
+        delegates here; its own detect_smart_recommendations() (advanced
+        pattern-based detections: stale conda envs, orphan node_modules,
+        etc.) stays CLI-only and is appended on top of what this returns.
+
+        Every recommendation carries a stable 'id' slug so callers (and
+        future per-rule config) don't have to match on the Spanish display
+        'type' string, which can change and already differed between the
+        two former copies.
+        """
         recommendations = []
 
         # TIER 1: Seguro
         log_locs = [l for l in self.cache_locations if l['type'] == cache_types.LOGS]
         if log_locs and sum(l['size'] for l in log_locs) > 10 * MB:
-            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
+            recommendations.append({'id': 'logs', 'tier': 1, 'priority': 'Seguro', 'type': cache_types.LOGS,
                 'description': f'{self.format_size(sum(l["size"] for l in log_locs))} en logs',
                 'space': sum(l['size'] for l in log_locs),
                 'command': comandos.borrar_contenido([l['path'] for l in log_locs]),
@@ -575,14 +589,14 @@ class DiskAnalyzerCore:
         brew_files = [f for f in self.large_files if 'Homebrew/downloads' in f['path']]
         if brew_files:
             size = sum(f['size'] for f in brew_files)
-            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de Homebrew',
+            recommendations.append({'id': 'homebrew', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de Homebrew',
                 'description': f'{len(brew_files)} descargas ({self.format_size(size)})',
                 'space': size, 'command': 'brew cleanup --prune=all',
                 'efecto': 'irreversible'})
 
         vscode_locs = [l for l in self.cache_locations if l['type'] == cache_types.VSCODE]
         if vscode_locs and sum(l['size'] for l in vscode_locs) > 10 * MB:
-            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
+            recommendations.append({'id': 'vscode', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de VS Code',
                 'description': f'{self.format_size(sum(l["size"] for l in vscode_locs))} en cache',
                 'space': sum(l['size'] for l in vscode_locs),
                 'command': comandos.borrar_contenido([l['path'] for l in vscode_locs]),
@@ -590,16 +604,20 @@ class DiskAnalyzerCore:
 
         npm_locs = [l for l in self.cache_locations if l['type'] == cache_types.NPM]
         if npm_locs and sum(l['size'] for l in npm_locs) > 50 * MB:
-            recommendations.append({'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
+            recommendations.append({'id': 'npm', 'tier': 1, 'priority': 'Seguro', 'type': 'Cache de npm',
                 'description': f'{self.format_size(sum(l["size"] for l in npm_locs))} en cache',
                 'space': sum(l['size'] for l in npm_locs), 'command': 'npm cache clean --force',
                 'efecto': 'irreversible'})
 
         # TIER 2: Moderado
+        # This rule used to exist in both copies under different display
+        # names ('Cache de Simuladores' here, 'Cache de Simuladores iOS' in
+        # the CLI) but with the identical condition, tier and command --
+        # same rule, drifted label. Unified under the core's label.
         sim_files = [f for f in self.large_files
                      if 'CoreSimulator' in f['path'] and not self.is_protected_path(f['path'])]
         if sim_files:
-            recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Cache de Simuladores',
+            recommendations.append({'id': 'simuladores', 'tier': 2, 'priority': 'Moderado', 'type': 'Cache de Simuladores',
                 'description': f'{len(sim_files)} archivos ({self.format_size(sum(f["size"] for f in sim_files))})',
                 'space': sum(f['size'] for f in sim_files),
                 'command': 'xcrun simctl delete unavailable && rm -rf ~/Library/Developer/CoreSimulator/Caches/',
@@ -608,13 +626,13 @@ class DiskAnalyzerCore:
         old_downloads = [f for f in self.large_files if '/Downloads/' in f['path'] and f['age_days'] > 30]
         if old_downloads:
             size = sum(f['size'] for f in old_downloads)
-            recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Descargas Antiguas',
+            recommendations.append({'id': 'descargas_antiguas', 'tier': 2, 'priority': 'Moderado', 'type': 'Descargas Antiguas',
                 'description': f'{len(old_downloads)} archivos ({self.format_size(size)})',
                 'space': size, 'command': 'find ~/Downloads -mtime +30 -type f -ls',
                 'efecto': 'solo_lista'})
 
         if self.docker_stats and self.docker_stats['available'] and self.docker_stats['reclaimable'] > 100 * MB:
-            recommendations.append({'tier': 2, 'priority': 'Moderado', 'type': 'Docker',
+            recommendations.append({'id': 'docker', 'tier': 2, 'priority': 'Moderado', 'type': 'Docker',
                 'description': f'{self.format_size(self.docker_stats["reclaimable"])} recuperable',
                 'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f',
                 'efecto': 'irreversible'})
@@ -622,18 +640,49 @@ class DiskAnalyzerCore:
         # TIER 3: Agresivo
         cache_general = [l for l in self.cache_locations if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]
         if cache_general and sum(l['size'] for l in cache_general) > 100 * MB:
-            recommendations.append({'tier': 3, 'priority': 'Agresivo', 'type': 'Cache General (~/.cache)',
+            recommendations.append({'id': 'cache_general', 'tier': 3, 'priority': 'Agresivo', 'type': 'Cache General (~/.cache)',
                 'description': f'{self.format_size(sum(l["size"] for l in cache_general))} (modelos ML, pip, etc.)',
                 'space': sum(l['size'] for l in cache_general),
                 'command': 'du -sh ~/.cache/*/ | sort -hr | head -20',
                 'efecto': 'solo_lista'})
 
+        # Moved here from the CLI-only copy of this method (it existed only
+        # there, so it would have silently disappeared for web users -- and
+        # from the menu-bar app too, once the CLI stopped duplicating it).
+        xcode_locs = [l for l in self.cache_locations if l['type'] == cache_types.XCODE]
+        if xcode_locs and sum(l['size'] for l in xcode_locs) > 100 * MB:
+            recommendations.append({'id': 'xcode_deriveddata', 'tier': 3, 'priority': 'Agresivo', 'type': 'Xcode DerivedData',
+                'description': f'{self.format_size(sum(l["size"] for l in xcode_locs))} en datos de compilación (se regeneran al compilar)',
+                'space': sum(l['size'] for l in xcode_locs),
+                'command': comandos.borrar_contenido([l['path'] for l in xcode_locs]),
+                'efecto': 'borra'})
+
+        # Moved here from the CLI-only copy (see comment above).
+        sim_runtimes = [f for f in self.large_files
+                        if 'iOSSimulatorRuntime' in f['path'] or 'SimRuntime' in f['path']]
+        if sim_runtimes and sum(f['size'] for f in sim_runtimes) > GB:
+            recommendations.append({'id': 'runtimes_simuladores', 'tier': 3, 'priority': 'Agresivo', 'type': 'Runtimes de Simuladores',
+                'description': f'{self.format_size(sum(f["size"] for f in sim_runtimes))} en runtimes de iOS Simulator (eliminar desde Xcode > Settings > Platforms)',
+                'space': sum(f['size'] for f in sim_runtimes),
+                'command': 'xcrun simctl runtime list',
+                'efecto': 'solo_lista'})
+
         # TIER 4: Máximo
         huge = [f for f in self.large_files if f['size'] > GB and not self.is_protected_path(f['path'])]
         if huge:
-            recommendations.append({'tier': 4, 'priority': 'Máximo', 'type': 'Archivos Gigantes',
+            recommendations.append({'id': 'archivos_gigantes', 'tier': 4, 'priority': 'Máximo', 'type': 'Archivos Gigantes',
                 'description': f'{len(huge)} archivos > 1GB ({self.format_size(sum(f["size"] for f in huge))})',
                 'space': sum(f['size'] for f in huge), 'command': '# Revisa la lista de archivos grandes',
+                'efecto': 'solo_lista'})
+
+        # Moved here from the CLI-only copy (see comment above).
+        vm_files = [f for f in self.large_files
+                    if any(ext in f['extension'] for ext in ['.vmdk', '.vdi', '.qcow2'])]
+        if vm_files:
+            recommendations.append({'id': 'maquinas_virtuales', 'tier': 4, 'priority': 'Máximo', 'type': 'Máquinas Virtuales',
+                'description': f'{len(vm_files)} archivos de VMs ({self.format_size(sum(f["size"] for f in vm_files))})',
+                'space': sum(f['size'] for f in vm_files),
+                'command': 'find / -name "*.vmdk" -o -name "*.vdi" -o -name "*.qcow2" 2>/dev/null | head -20',
                 'efecto': 'solo_lista'})
 
         return sorted(recommendations, key=lambda x: (x['tier'], -x['space']))

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -613,6 +613,17 @@ class DiskAnalyzerCore:
                 'space': sum(l['size'] for l in npm_locs), 'command': 'npm cache clean --force',
                 'efecto': 'irreversible'})
 
+        # La papelera: espacio que el usuario ya decidió tirar. Nivel 1 sin
+        # discusión, y además es lo único que hace que "mover a la papelera"
+        # libere algo de verdad en el mismo volumen.
+        papelera = [l for l in self.cache_locations if l['type'] == cache_types.TRASH]
+        if papelera and sum(l['size'] for l in papelera) > 100 * MB:
+            total = sum(l['size'] for l in papelera)
+            recommendations.append({'id': 'papelera', 'tier': 1, 'priority': 'Seguro', 'type': cache_types.TRASH,
+                'description': f'{self.format_size(total)} ya en la papelera',
+                'space': total, 'efecto': 'borra',
+                'command': comandos.borrar_contenido([l['path'] for l in papelera])})
+
         # TIER 2: Moderado
         # This rule used to exist in both copies under different display
         # names ('Cache de Simuladores' here, 'Cache de Simuladores iOS' in
@@ -646,6 +657,32 @@ class DiskAnalyzerCore:
                 'description': f'{self.format_size(self.docker_stats["reclaimable"])} recuperable de {self.format_size(self.docker_stats.get("total_size", 0))} total',
                 'space': self.docker_stats['reclaimable'], 'command': 'docker system prune -a -f',
                 'efecto': 'irreversible'})
+
+        # Cachés de aplicaciones: 21,4 GB medidos en la máquina de desarrollo y
+        # ninguna regla los miraba. Nivel 2 y no 1 porque algunas apps guardan
+        # ahí cosas que tardan en regenerarse (índices, miniaturas).
+        #
+        # IMPORTANT: cache_types.GENERAL también agrupa
+        # ~/Library/Developer/CoreSimulator/Devices (simuladores instalados,
+        # no una caché regenerable) y /private/var/folders (gestionado por
+        # macOS -- ver protection.py y test_puede_borrarse.py). Filtrar solo
+        # por type aquí arrastraría ambos a un 'efecto: borra' que no les
+        # corresponde -- el mismo defecto que ya se coló una vez con
+        # cache_types.XCODE y DerivedData/Archives (ver el comentario en
+        # xcode_deriveddata más abajo). Por eso esta regla acota también por
+        # ruta, a 'Library/Caches' explícitamente.
+        app_caches = [l for l in self.cache_locations
+                      if l['type'] == cache_types.GENERAL
+                      and 'Library/Caches' in l['path']]
+        if app_caches and sum(l['size'] for l in app_caches) > 500 * MB:
+            total = sum(l['size'] for l in app_caches)
+            recommendations.append({
+                'id': 'caches_de_apps', 'tier': 2, 'priority': 'Moderado',
+                'type': 'Cachés de aplicaciones',
+                'description': f'{self.format_size(total)} en ~/Library/Caches',
+                'space': total, 'efecto': 'borra',
+                'command': comandos.borrar_contenido(
+                    [l['path'] for l in app_caches])})
 
         # TIER 3: Agresivo
         cache_general = [l for l in self.cache_locations if l['type'] == cache_types.GENERAL and '/.cache' in l['path']]

--- a/disk_analyzer_core.py
+++ b/disk_analyzer_core.py
@@ -626,9 +626,15 @@ class DiskAnalyzerCore:
         old_downloads = [f for f in self.large_files if '/Downloads/' in f['path'] and f['age_days'] > 30]
         if old_downloads:
             size = sum(f['size'] for f in old_downloads)
+            # Fold in the user's configured min_size (self.min_size, in bytes,
+            # set in __init__ with a 10 MB default) so the diagnostic only
+            # lists files worth reviewing -- without this, "old downloads"
+            # includes every tiny file older than 30 days, which is a
+            # longer and less useful list than what the CLI used to show.
+            min_size_mb = int(self.min_size / MB)
             recommendations.append({'id': 'descargas_antiguas', 'tier': 2, 'priority': 'Moderado', 'type': 'Descargas Antiguas',
                 'description': f'{len(old_downloads)} archivos ({self.format_size(size)})',
-                'space': size, 'command': 'find ~/Downloads -mtime +30 -type f -ls',
+                'space': size, 'command': f'find ~/Downloads -mtime +30 -size +{min_size_mb}M -type f -ls',
                 'efecto': 'solo_lista'})
 
         if self.docker_stats and self.docker_stats['available'] and self.docker_stats['reclaimable'] > 100 * MB:

--- a/disk_analyzer_web.py
+++ b/disk_analyzer_web.py
@@ -28,7 +28,7 @@ import uvicorn
 
 # Import our core analyzer
 from disk_analyzer_core import DiskAnalyzerCore, MB, GB, IS_MACOS, IS_WINDOWS
-from analyzer.protection import is_protected_path
+from analyzer.protection import is_protected_path, puede_borrarse
 from pty_manager import PTYManager
 from agents_manager import AgentsManager
 from persona_detector import detect_personas, generate_persona_recommendations
@@ -893,7 +893,19 @@ def _perform_cleanup_deletes(actions: list) -> tuple:
 
     for action in actions:
         target = Path(action["path"]).resolve()
-        if is_protected_path(str(target)):
+        # is_protected_path is an OS blacklist -- it says nothing about user
+        # data (~/Downloads, ~/Documents, iCloud Drive, ... all come back
+        # False from it, i.e. "deletable"). The gate that answers the actual
+        # question here -- is it SAFE to delete this without a human looking
+        # -- is analyzer.protection.puede_borrarse, the same one
+        # analyzer/comandos.py installs in front of every generated shell
+        # command. This endpoint deletes directly via shutil.rmtree/unlink,
+        # bypassing comandos.py entirely, so it needs its own call to the
+        # gate. Verified against the real home: of 10 targets, two that
+        # puede_borrarse explicitly forbids (~/Downloads,
+        # ~/Library/Developer/CoreSimulator/Devices) were deleted anyway
+        # under the old is_protected_path-only filter.
+        if not puede_borrarse(str(target)):
             errors.append({"path": str(target), "error": "Ruta protegida del sistema"})
             continue
         try:

--- a/docs/runbooks/app-bandeja.md
+++ b/docs/runbooks/app-bandeja.md
@@ -20,9 +20,15 @@ mover a otro Mac.
 
 ## "Abrir analizador completo"
 
-El ítem arranca el servidor web empaquetado y abre el navegador en él. Si ya
-había uno escuchando en el 8000 —por ejemplo un `make web` tuyo—, lo reutiliza
-en vez de pelearse por el puerto.
+El ítem arranca el servidor web empaquetado en un **puerto efímero** que pide al
+sistema, y abre el navegador en él. Solo reutiliza un servidor si es el que
+arrancó la propia app y su proceso sigue vivo.
+
+Antes usaba el 8000 fijo y solo comprobaba que *algo* aceptara conexiones ahí,
+así que un Django o un Rails tuyo en ese puerto se abría en el navegador como si
+fuera el analizador. Como la app abre el navegador ella misma, el número de
+puerto nunca lo ves: fijarlo solo servía para chocar. `make web` se queda con el
+8000, que es su comportamiento documentado.
 
 **Se ata solo a `127.0.0.1`, no a toda la red.** El servidor por defecto escucha
 en `0.0.0.0` porque el acceso desde otros dispositivos es una función

--- a/docs/superpowers/plans/2026-08-21-saneamiento-limpieza.md
+++ b/docs/superpowers/plans/2026-08-21-saneamiento-limpieza.md
@@ -1,0 +1,1331 @@
+# Saneamiento de la limpieza — Plan de implementación
+
+> **Para agentes:** SUB-SKILL REQUERIDO: usa `superpowers:subagent-driven-development`
+> (recomendado) o `superpowers:executing-plans` para ejecutar este plan task por
+> task. Los pasos usan casillas (`- [ ]`) para seguimiento.
+
+**Objetivo:** dejar la limpieza en un estado en el que se pueda construir encima
+— sin inyección de shell, sin comandos que mienten, con una sola definición de
+los niveles de riesgo y sin secuestrar el puerto 8000.
+
+**Arquitectura:** los comandos de borrado dejan de construirse a mano en cada
+sitio y pasan por un único constructor con escapado; el ahorro se mide del disco
+en vez de deducirse del código de salida; las dos copias de
+`generate_recommendations` se fusionan en una, con un `id` estable por
+recomendación; y la app de bandeja pide un puerto libre al sistema en lugar de
+asumir el 8000.
+
+**Stack:** Python 3.13 (solo biblioteca estándar en el motor), pytest, React +
+Vitest en el frontend, Rust + Tauri 2 en la app de bandeja.
+
+**Origen:** este plan no nace de un spec sino de cinco revisiones adversariales
+sobre la propuesta de añadir acciones de limpieza al menú de la bandeja. Los
+hallazgos están reproducidos abajo. El spec de la app de bandeja sigue siendo
+[`docs/superpowers/specs/2026-08-19-app-bandeja-tauri-design.md`](../specs/2026-08-19-app-bandeja-tauri-design.md).
+
+## Restricciones globales
+
+- El motor (`disk_analyzer.py`, `disk_analyzer_core.py`, `analyzer/`) usa **solo
+  biblioteca estándar**. `shlex` lo es; no añadir dependencias.
+- Mensajes de cara al usuario en **español**; comentarios de código en inglés.
+- **Desarrollo guiado por tests:** el test falla primero, luego el arreglo.
+- La suite existente —153 backend, 72 frontend, 17 Rust— debe quedar en verde.
+- **Un commit por task**, mensaje en español.
+- No cambiar las formas del API que consume `web/src/lib/api.ts`, salvo para
+  **añadir** campos opcionales.
+- La app de bandeja ejecuta `disk_analyzer.py` (no el core): ver
+  `desktop/src-tauri/src/analisis.rs`. Cualquier arreglo que solo toque el core
+  no llega a la bandeja.
+
+---
+
+## Hallazgos verificados que originan este plan
+
+Los cinco están **reproducidos**, no supuestos.
+
+**H1 — Inyección de shell por el nombre de una carpeta (crítico).**
+`disk_analyzer_core.py:571,585` y `disk_analyzer.py:758,881,904,929` construyen
+`f"rm -rf '{path}/*'"` sin escapar. Una carpeta llamada
+`x' ; rm -rf victim ; touch pwned '` genera tres comandos encadenados.
+Reproducido: borró una carpeta ajena y ejecutó código arbitrario. La ruta la
+aporta el escaneo del disco. Bajo `sudo make web`, corre como root.
+
+El escapado correcto **ya existe** en `disk_analyzer.py:662`
+(`file_path.replace("'", "'\"'\"'")`); el generador de recomendaciones no lo
+llama.
+
+**H2 — Los comandos de logs y VS Code no borran nada y salen con éxito.**
+El `*` va **dentro** de las comillas simples, así que el shell no lo expande.
+Reproducido: `rm -rf 'dir/*'` → código 0, el fichero sigue ahí. Y
+`web/src/hooks/useCleanupRunner.ts:168-172` acredita el ahorro al ver código 0.
+Resultado: la interfaz dice "liberados 85 MB" habiendo borrado cero bytes.
+
+Nota: `disk_analyzer.py:881` pone el glob **fuera** de las comillas y sí
+funciona. El bug es incoherencia entre sitios.
+
+**H3 — Un `tier` desconocido se trata como Seguro.**
+`web/src/components/CleanupWizard.tsx:37,40,46,50` hace `r.tier || 1`. Una
+recomendación con `tier` ausente, `null` o `0` entra en el botón de ejecución
+por lotes del nivel 1. Lo desconocido debe caer en lo más restrictivo.
+
+**H4 — `is_protected_path` no protege datos de usuario.**
+Verificado: devuelve `False` (borrable) para `~/Documents`, `~/Desktop`,
+`~/Library/Mobile Documents` (iCloud), `/Volumes/Backup Time Machine` y el
+propio `$HOME`. Es una lista negra del sistema operativo, no una whitelist de lo
+que se puede borrar. Además los prefijos llevan barra final
+(`analyzer/constants.py:99-111`), así que `/System/Library` (el directorio en sí)
+tampoco está protegido, solo su contenido.
+
+**H5 — La bandeja abre lo que sea que haya en el puerto 8000.**
+`desktop/src-tauri/src/servidor.rs` comprueba solo que *algo* acepte TCP en
+127.0.0.1:8000 y, si lo hay, abre esa URL como si fuera el analizador. Con un
+Django o un Rails en el 8000, "Abrir analizador completo" abre esa aplicación.
+
+---
+
+## Estructura de archivos
+
+| Archivo | Responsabilidad |
+|---|---|
+| `analyzer/comandos.py` *(nuevo)* | Único constructor de comandos de borrado. Escapa rutas, coloca el glob fuera de las comillas y clasifica el efecto de cada comando. |
+| `analyzer/protection.py` | Añade `puede_borrarse()`: whitelist real, además de la lista negra existente. |
+| `analyzer/constants.py` | Añade `RUTAS_DE_DATOS_DE_USUARIO`. |
+| `disk_analyzer_core.py` | Única `generate_recommendations`, con `id` estable y campo `efecto`. Reglas nuevas. |
+| `disk_analyzer.py` | Su `generate_recommendations` pasa a delegar en el core. |
+| `web/src/lib/api.ts` | Tipo `Recommendation` con `id` y `efecto` opcionales. |
+| `web/src/hooks/useCleanupRunner.ts` | Acredita el ahorro medido del disco, no el estimado. |
+| `web/src/components/CleanupWizard.tsx` | Lo desconocido deja de ser Seguro. |
+| `desktop/src-tauri/src/servidor.rs` | Puerto efímero y reutilización solo de instancias propias. |
+
+---
+
+## Fase 1 — Seguridad
+
+### Task 1: Un único constructor de comandos de borrado
+
+**Archivos:**
+- Crear: `analyzer/comandos.py`
+- Crear: `tests/test_comandos.py`
+- Modificar: `disk_analyzer_core.py:571,585`, `disk_analyzer.py:758,881,904,929`
+
+**Interfaces:**
+- Consume: nada.
+- Produce: `borrar_contenido(paths: List[str]) -> str`,
+  `borrar_rutas(paths: List[str]) -> str`, `escapar(path: str) -> str`.
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```python
+# tests/test_comandos.py
+"""El constructor de comandos de borrado.
+
+Los dos fallos que estos tests fijan estaban en producción y se reprodujeron:
+una carpeta con un apóstrofe en el nombre ejecutaba comandos arbitrarios, y el
+glob entrecomillado hacía que el borrado no borrara nada y saliera con éxito.
+"""
+import os
+import subprocess
+import tempfile
+
+from analyzer.comandos import borrar_contenido, borrar_rutas, escapar
+
+
+def _ejecutar(cmd: str, cwd: str) -> int:
+    return subprocess.run(["/bin/sh", "-c", cmd], cwd=cwd,
+                          capture_output=True).returncode
+
+
+def test_una_ruta_maliciosa_no_ejecuta_comandos_extra():
+    """El nombre de una carpeta no puede ser código.
+
+    Reproducido en producción: `x' ; rm -rf victim ; touch pwned '` con la
+    plantilla vieja generaba tres comandos y borraba una carpeta ajena.
+    """
+    with tempfile.TemporaryDirectory() as box:
+        os.makedirs(os.path.join(box, "victima"))
+        malicioso = os.path.join(box, "x' ; rm -rf victima ; touch pwned '")
+        os.makedirs(malicioso)
+
+        _ejecutar(borrar_contenido([malicioso]), cwd=box)
+
+        assert os.path.isdir(os.path.join(box, "victima")), (
+            "el nombre de otra carpeta consiguió borrar la víctima"
+        )
+        assert not os.path.exists(os.path.join(box, "pwned")), (
+            "se ejecutó un comando arbitrario embebido en el nombre"
+        )
+
+
+def test_borrar_contenido_borra_de_verdad():
+    """El glob tiene que quedar FUERA de las comillas o no expande.
+
+    Con `rm -rf 'dir/*'` el shell trata el asterisco como literal, `rm -f` sale
+    0 y no borra nada. La interfaz acreditaba el ahorro por ese 0.
+    """
+    with tempfile.TemporaryDirectory() as box:
+        objetivo = os.path.join(box, "cache")
+        os.makedirs(objetivo)
+        open(os.path.join(objetivo, "a.log"), "w").write("x")
+        open(os.path.join(objetivo, "b.log"), "w").write("x")
+
+        _ejecutar(borrar_contenido([objetivo]), cwd=box)
+
+        assert os.listdir(objetivo) == [], "el contenido sobrevivió al borrado"
+        assert os.path.isdir(objetivo), "borró el directorio, no su contenido"
+
+
+def test_borrar_rutas_borra_el_directorio_entero():
+    with tempfile.TemporaryDirectory() as box:
+        objetivo = os.path.join(box, "basura")
+        os.makedirs(objetivo)
+        _ejecutar(borrar_rutas([objetivo]), cwd=box)
+        assert not os.path.exists(objetivo)
+
+
+def test_escapar_neutraliza_metacaracteres():
+    for peligro in ["a'b", "a b", "a;b", "a&&b", "a$(id)b", "a`id`b", "a\nb"]:
+        assert escapar(peligro) != peligro or "'" not in peligro
+
+
+def test_una_ruta_vacia_no_produce_comando():
+    """Una ruta vacía convertiría `rm -rf ''/*` en algo impredecible."""
+    assert borrar_contenido([]) == ""
+    assert borrar_contenido([""]) == ""
+    assert borrar_rutas(["   "]) == ""
+
+
+def test_la_raiz_nunca_genera_comando():
+    """Salvaguarda de último recurso: nada construye un borrado de `/`."""
+    assert borrar_contenido(["/"]) == ""
+    assert borrar_rutas(["/"]) == ""
+```
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+venv-web/bin/python -m pytest tests/test_comandos.py -v
+```
+Esperado: FAIL con `ModuleNotFoundError: No module named 'analyzer.comandos'`.
+
+- [ ] **Paso 3: Escribe el módulo**
+
+```python
+# analyzer/comandos.py
+"""Único sitio donde se construyen comandos de borrado.
+
+Antes cada sitio armaba su propia f-string. Eso produjo dos fallos que llegaron
+a producción y se reprodujeron:
+
+- Una carpeta llamada `x' ; rm -rf victim ; touch pwned '` cerraba las comillas
+  de la plantilla y ejecutaba comandos arbitrarios. La ruta la aporta el escaneo
+  del disco, así que basta con descomprimir un zip con un nombre hostil.
+- El glob iba DENTRO de las comillas (`rm -rf 'dir/*'`), así que el shell no lo
+  expandía: `rm -f` salía 0 sin borrar nada, y la interfaz acreditaba el ahorro
+  al ver ese 0.
+
+`shlex.quote` es biblioteca estándar, así que esto no rompe la promesa de que el
+motor no tiene dependencias.
+"""
+import shlex
+from typing import List
+
+# Rutas que jamás pueden ser el objetivo de un comando generado, por muy
+# protegida que esté la lógica que llama aquí. Es la última red, no la primera.
+_PROHIBIDAS = {"/", "//", "/.", ""}
+
+
+def escapar(path: str) -> str:
+    """Deja una ruta lista para incrustarse en una línea de shell."""
+    return shlex.quote(path)
+
+
+def _utiles(paths: List[str]) -> List[str]:
+    limpias = []
+    for p in paths:
+        p = (p or "").rstrip("/") if (p or "").rstrip("/") else (p or "")
+        if p.strip() in _PROHIBIDAS or not p.strip():
+            continue
+        limpias.append(p)
+    return limpias
+
+
+def borrar_contenido(paths: List[str]) -> str:
+    """Borra lo que hay DENTRO de cada ruta, dejando el directorio en pie.
+
+    El glob va fuera de las comillas a propósito: dentro, el shell lo trata como
+    un nombre de fichero literal y el comando no borra nada.
+    """
+    limpias = _utiles(paths)
+    if not limpias:
+        return ""
+    return " && ".join(f"rm -rf {escapar(p)}/*" for p in limpias)
+
+
+def borrar_rutas(paths: List[str]) -> str:
+    """Borra cada ruta entera, el directorio incluido."""
+    limpias = _utiles(paths)
+    if not limpias:
+        return ""
+    return " && ".join(f"rm -rf {escapar(p)}" for p in limpias)
+```
+
+- [ ] **Paso 4: Verifica que pasan**
+
+```bash
+venv-web/bin/python -m pytest tests/test_comandos.py -v
+```
+Esperado: 6 passed.
+
+- [ ] **Paso 5: Reemplaza los seis sitios vulnerables**
+
+En `disk_analyzer_core.py`, añade `from analyzer import comandos` junto a los
+otros imports de `analyzer`, y sustituye:
+
+```python
+# línea ~571 y ~585 — antes:
+'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)
+# después:
+'command': comandos.borrar_contenido([l['path'] for l in log_locs])
+```
+
+En `disk_analyzer.py`, mismo import, y sustituye:
+
+```python
+# línea ~758 — antes:
+'command': f"rm -rf '{dir_path}'",
+# después:
+'command': comandos.borrar_rutas([dir_path]),
+
+# línea ~881 — antes:
+'command': f"rm -rf '{xcode_archives_path}'/*",
+# después:
+'command': comandos.borrar_contenido([xcode_archives_path]),
+
+# líneas ~904 y ~929 — antes:
+'command': ' && '.join(f"rm -rf '{l['path']}/*'" for l in log_locs)
+# después:
+'command': comandos.borrar_contenido([l['path'] for l in log_locs])
+```
+
+Verifica antes de sustituir el nombre real de la variable en cada sitio: la de
+la línea 929 es de VS Code, no de logs.
+
+- [ ] **Paso 6: Verifica que no queda ninguna plantilla a mano**
+
+```bash
+grep -n "rm -rf '" disk_analyzer.py disk_analyzer_core.py
+```
+Esperado: solo `disk_analyzer.py:663` (el borrado de fichero suelto, que ya
+escapa) y las cadenas dentro del HTML generado.
+
+- [ ] **Paso 7: La suite completa sigue verde**
+
+```bash
+venv-web/bin/python -m pytest tests/ -q
+```
+Esperado: 153 passed + los 6 nuevos.
+
+- [ ] **Paso 8: Commit**
+
+```bash
+git add analyzer/comandos.py tests/test_comandos.py disk_analyzer.py disk_analyzer_core.py
+git commit -m "fix: el nombre de una carpeta ya no puede ejecutar comandos"
+```
+
+---
+
+### Task 2: Whitelist real para lo que se puede borrar
+
+**Archivos:**
+- Modificar: `analyzer/constants.py`, `analyzer/protection.py`
+- Crear: `tests/test_puede_borrarse.py`
+
+**Interfaces:**
+- Consume: `is_protected_path(path) -> bool` (existente).
+- Produce: `puede_borrarse(path: str) -> bool`.
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```python
+# tests/test_puede_borrarse.py
+"""Qué se puede borrar de verdad.
+
+`is_protected_path` es una lista negra del sistema operativo: sirve para "no
+toques macOS", no para "esto es seguro de borrar". Verificado: devuelve False
+(borrable) para ~/Documents, ~/Desktop, iCloud Drive, /Volumes/... y el propio
+$HOME. Con "añadir carpetas propias" eso apuntaría a los datos del usuario.
+"""
+import os
+
+import pytest
+
+from analyzer.protection import puede_borrarse
+
+CASA = os.path.expanduser("~")
+
+
+@pytest.mark.parametrize("ruta", [
+    CASA,
+    os.path.join(CASA, "Documents"),
+    os.path.join(CASA, "Desktop"),
+    os.path.join(CASA, "Pictures"),
+    os.path.join(CASA, "Library/Mobile Documents"),          # iCloud Drive
+    os.path.join(CASA, "Library/Mobile Documents/algo/mio"),  # y su contenido
+    "/Volumes/Backup Time Machine",
+    "/Volumes/Backup Time Machine/2026",
+    "/System/Library",     # el directorio en sí, no solo su contenido
+    "/System",
+    "/",
+])
+def test_los_datos_del_usuario_y_el_sistema_no_se_borran(ruta):
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable"
+
+
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "Library/Caches/com.apple.Safari"),
+    os.path.join(CASA, ".npm/_cacache"),
+    os.path.join(CASA, "Library/Logs/algo.log"),
+])
+def test_las_caches_conocidas_si_se_borran(ruta):
+    assert puede_borrarse(ruta), f"{ruta} debería poder limpiarse"
+
+
+def test_una_ruta_relativa_o_vacia_nunca_se_borra():
+    assert not puede_borrarse("")
+    assert not puede_borrarse("relativa/sin/raiz")
+
+
+def test_no_se_puede_escapar_con_puntos():
+    """`~/Library/Caches/../../Documents` es ~/Documents disfrazado."""
+    assert not puede_borrarse(os.path.join(CASA, "Library/Caches/../../Documents"))
+```
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+venv-web/bin/python -m pytest tests/test_puede_borrarse.py -v
+```
+Esperado: FAIL con `ImportError: cannot import name 'puede_borrarse'`.
+
+- [ ] **Paso 3: Añade las rutas de datos de usuario**
+
+En `analyzer/constants.py`, después del bloque `PROTECTED_PATH_PREFIXES`:
+
+```python
+# Rutas cuyo borrado destruye datos del usuario. `PROTECTED_PATH_PREFIXES` es
+# una lista negra del sistema operativo y no cubre nada de esto: verificado que
+# ~/Documents, iCloud Drive y /Volumes/... salían como borrables.
+#
+# Se guardan relativas a $HOME (o absolutas cuando no dependen del usuario) y se
+# expanden al comprobar, para que los tests no dependan de quién ejecuta.
+RUTAS_DE_DATOS_DE_USUARIO = [
+    '~',
+    '~/Documents',
+    '~/Desktop',
+    '~/Pictures',
+    '~/Movies',
+    '~/Music',
+    '~/Library/Mobile Documents',   # iCloud Drive
+    '~/Library/Messages',
+    '~/Library/Mail',
+    '~/Library/Photos',
+    '~/Library/Keychains',
+    '~/Library/Application Support/MobileSync',  # backups de iPhone
+    '/Volumes',                     # discos externos y Time Machine
+    '/Users',
+    '/System',
+    '/Library',
+    '/private',
+    '/usr',
+    '/etc',
+    '/var',
+    '/opt',
+    '/Applications',
+]
+```
+
+- [ ] **Paso 4: Implementa `puede_borrarse`**
+
+En `analyzer/protection.py`:
+
+```python
+import os
+
+from analyzer.constants import (
+    PROTECTED_PATH_PREFIXES, PROTECTED_APP_MARKERS, PROTECTED_FILENAMES,
+    PROTECTED_ROOT_DIRS, RUTAS_DE_DATOS_DE_USUARIO,
+)
+
+
+def puede_borrarse(file_path: str) -> bool:
+    """Si una ruta puede ser objetivo de un borrado automático.
+
+    Distinta de `is_protected_path`, que solo dice "esto es del sistema
+    operativo". Aquí la pregunta es la contraria y más estricta: ¿es seguro que
+    una herramienta borre esto sin que un humano lo mire? Ante la duda, no.
+
+    Se normaliza antes de comparar porque
+    `~/Library/Caches/../../Documents` es `~/Documents` disfrazado.
+    """
+    if not file_path or not file_path.strip():
+        return False
+
+    ruta = os.path.normpath(os.path.abspath(os.path.expanduser(file_path)))
+    if not ruta.startswith('/') or ruta == '/':
+        return False
+
+    if is_protected_path(ruta):
+        return False
+
+    for cruda in RUTAS_DE_DATOS_DE_USUARIO:
+        prohibida = os.path.normpath(os.path.expanduser(cruda))
+        # La ruta prohibida en sí, y todo lo que cuelga de ella salvo que una
+        # regla más específica lo permita (ver abajo).
+        if ruta == prohibida:
+            return False
+
+    # Dentro de una zona prohibida solo se salvan las cachés conocidas: eso es
+    # lo que convierte esto en whitelist y no en otra lista negra.
+    permitidas = [
+        os.path.expanduser('~/Library/Caches'),
+        os.path.expanduser('~/Library/Logs'),
+        os.path.expanduser('~/.cache'),
+        os.path.expanduser('~/.npm'),
+        os.path.expanduser('~/Library/Developer/Xcode/DerivedData'),
+        os.path.expanduser('~/Library/Application Support/Code/Cache'),
+        os.path.expanduser('~/Library/Application Support/Code/CachedData'),
+        os.path.expanduser('~/Library/Containers/com.docker.docker/Data'),
+        '/private/var/folders',
+    ]
+    if any(ruta == p or ruta.startswith(p + '/') for p in permitidas):
+        return True
+
+    for cruda in RUTAS_DE_DATOS_DE_USUARIO:
+        prohibida = os.path.normpath(os.path.expanduser(cruda))
+        if ruta.startswith(prohibida + '/'):
+            return False
+
+    return True
+```
+
+- [ ] **Paso 5: Arregla los prefijos sin barra final**
+
+En `analyzer/protection.py`, dentro de `is_protected_path`, el chequeo de
+prefijos solo cubre el contenido porque los prefijos llevan barra final. Cambia:
+
+```python
+    if any(file_path.startswith(prefix) for prefix in PROTECTED_PATH_PREFIXES):
+        return True
+```
+
+por:
+
+```python
+    # `startswith('/System/Library/')` no cubre '/System/Library' a secas, así
+    # que el directorio en sí quedaba desprotegido y solo lo estaba su contenido.
+    for prefix in PROTECTED_PATH_PREFIXES:
+        if file_path.startswith(prefix) or file_path == prefix.rstrip('/'):
+            return True
+```
+
+- [ ] **Paso 6: Verifica que pasan y que no rompiste nada**
+
+```bash
+venv-web/bin/python -m pytest tests/test_puede_borrarse.py -v
+venv-web/bin/python -m pytest tests/ -q
+```
+Esperado: los nuevos en verde, los 153 anteriores intactos.
+
+- [ ] **Paso 7: Commit**
+
+```bash
+git add analyzer/constants.py analyzer/protection.py tests/test_puede_borrarse.py
+git commit -m "fix: whitelist real de lo que se puede borrar"
+```
+
+---
+
+### Task 3: Lo desconocido deja de ser Seguro
+
+**Archivos:**
+- Modificar: `web/src/components/CleanupWizard.tsx:37,40,46,50`
+- Crear: `web/src/components/CleanupWizard.tiers.test.tsx`
+
+- [ ] **Paso 1: Escribe el test que falla**
+
+```tsx
+// web/src/components/CleanupWizard.tsx usa `r.tier || 1`, así que una
+// recomendación sin nivel cae en el grupo Seguro y entra en el botón que
+// ejecuta todo el nivel 1 de una vez. El default ante lo desconocido tiene que
+// ser el más restrictivo, no el más permisivo.
+import { describe, it, expect } from 'vitest';
+import { nivelDe } from './CleanupWizard';
+
+describe('nivelDe', () => {
+  it('respeta el nivel cuando viene', () => {
+    expect(nivelDe({ tier: 1 })).toBe(1);
+    expect(nivelDe({ tier: 3 })).toBe(3);
+  });
+
+  it('trata lo desconocido como lo más restrictivo, no como Seguro', () => {
+    for (const rec of [{}, { tier: undefined }, { tier: null }, { tier: 0 },
+                       { tier: NaN }, { tier: 'dos' }, { tier: 9 }]) {
+      expect(nivelDe(rec as any)).toBe(4);
+    }
+  });
+});
+```
+
+- [ ] **Paso 2: Ejecútalo para verificar que falla**
+
+```bash
+cd web && npm test -- --run src/components/CleanupWizard.tiers.test.tsx
+```
+Esperado: FAIL, `nivelDe` no está exportado.
+
+- [ ] **Paso 3: Implementa y sustituye los cuatro usos**
+
+En `web/src/components/CleanupWizard.tsx`, arriba del componente:
+
+```tsx
+/**
+ * El nivel de riesgo de una recomendación, o el más restrictivo si no se
+ * puede saber.
+ *
+ * El código anterior hacía `r.tier || 1`, que convertía `undefined`, `null` y
+ * `0` en Seguro — y Seguro es justo lo que el botón de "ejecutar todo" lanza
+ * sin revisión. Ante una recomendación malformada, lo correcto es lo contrario.
+ */
+export function nivelDe(rec: { tier?: unknown }): number {
+  const n = Number(rec?.tier);
+  return Number.isInteger(n) && n >= 1 && n <= 4 ? n : 4;
+}
+```
+
+Y reemplaza las cuatro apariciones de `(r.tier || 1)` / `rec.tier || 1` por
+`nivelDe(r)` / `nivelDe(rec)`.
+
+- [ ] **Paso 4: Verifica**
+
+```bash
+cd web && npm test -- --run && npm run check
+```
+Esperado: todo verde, 0 errores de tipos.
+
+- [ ] **Paso 5: Commit**
+
+```bash
+git add web/src/components/CleanupWizard.tsx web/src/components/CleanupWizard.tiers.test.tsx
+git commit -m "fix(web): una recomendación sin nivel ya no cuenta como segura"
+```
+
+---
+
+## Fase 2 — Honestidad sobre lo que pasa
+
+### Task 4: Etiquetar el efecto real de cada comando
+
+**Archivos:**
+- Modificar: `disk_analyzer_core.py` (todas las recomendaciones)
+- Modificar: `web/src/lib/api.ts` (tipo `Recommendation`)
+- Crear: `tests/test_efecto_recomendaciones.py`
+
+**Interfaces:**
+- Produce: cada recomendación gana `'efecto'`, uno de
+  `'borra'` | `'irreversible'` | `'solo_lista'`.
+
+- [ ] **Paso 1: Escribe el test que falla**
+
+```python
+# tests/test_efecto_recomendaciones.py
+"""Cada recomendación tiene que declarar qué hace su comando.
+
+Hoy se mezclan tres cosas distintas bajo el mismo botón:
+- borrados de ficheros, que podrían ir a la papelera;
+- invocaciones a herramientas (`docker system prune`, `brew cleanup`), que
+  borran por su cuenta y NO tienen papelera posible;
+- diagnósticos (`du -sh`, `find -ls`), que no borran nada.
+
+Sin este campo, la interfaz no puede prometer reversibilidad honestamente ni
+distinguir "liberó espacio" de "te enseñó una lista".
+"""
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer_core import DiskAnalyzerCore
+
+EFECTOS = {'borra', 'irreversible', 'solo_lista'}
+
+
+def _recomendaciones():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    return core.generate_recommendations()
+
+
+def test_toda_recomendacion_declara_su_efecto():
+    for r in _recomendaciones():
+        assert r.get('efecto') in EFECTOS, (
+            f"{r.get('type')} no declara efecto válido: {r.get('efecto')!r}"
+        )
+
+
+def test_los_comandos_que_solo_listan_estan_marcados():
+    """`du -sh` y `find -ls` no borran; acreditarles ahorro es mentir."""
+    for r in _recomendaciones():
+        cmd = r.get('command', '')
+        if cmd.startswith('du ') or ' -ls' in cmd:
+            assert r['efecto'] == 'solo_lista', (
+                f"{r['type']} ejecuta un diagnóstico pero no está marcado"
+            )
+
+
+def test_las_herramientas_externas_son_irreversibles():
+    """Nada de esto se puede mandar a la papelera."""
+    for r in _recomendaciones():
+        cmd = r.get('command', '')
+        if any(t in cmd for t in ('docker system prune', 'brew cleanup',
+                                  'npm cache clean', 'simctl delete')):
+            assert r['efecto'] == 'irreversible', (
+                f"{r['type']} invoca una herramienta externa: no hay papelera"
+            )
+```
+
+- [ ] **Paso 2: Ejecútalo para verificar que falla**
+
+```bash
+venv-web/bin/python -m pytest tests/test_efecto_recomendaciones.py -v
+```
+Esperado: FAIL, ninguna recomendación declara `efecto`.
+
+- [ ] **Paso 3: Añade el campo en cada recomendación**
+
+En `disk_analyzer_core.py`, dentro de `generate_recommendations`, añade
+`'efecto'` a cada `recommendations.append({...})`:
+
+- logs, VS Code, Homebrew (`brew cleanup`), npm (`npm cache clean`):
+  `'efecto': 'irreversible'` para las que invocan herramientas,
+  `'efecto': 'borra'` para las que son `rm -rf` de rutas.
+- simuladores (`xcrun simctl delete unavailable`): `'irreversible'`.
+- Docker (`docker system prune -a -f`): `'irreversible'`.
+- Descargas antiguas (`find ~/Downloads ... -ls`): `'solo_lista'`.
+- Cache general `~/.cache` (`du -sh ...`): `'solo_lista'`.
+- Archivos gigantes: según su comando; si lista, `'solo_lista'`.
+
+Comprueba el comando real de cada bloque antes de etiquetarlo — no supongas por
+el nombre.
+
+- [ ] **Paso 4: Añade el campo al tipo del frontend**
+
+En `web/src/lib/api.ts`, en la interfaz de recomendación:
+
+```ts
+  /** Qué hace realmente el comando. Opcional: los informes viejos no lo traen. */
+  efecto?: 'borra' | 'irreversible' | 'solo_lista';
+  /** Identificador estable, ver Task 6. Opcional por la misma razón. */
+  id?: string;
+```
+
+- [ ] **Paso 5: Verifica**
+
+```bash
+venv-web/bin/python -m pytest tests/ -q
+cd web && npm run check
+```
+
+- [ ] **Paso 6: Commit**
+
+```bash
+git add disk_analyzer_core.py web/src/lib/api.ts tests/test_efecto_recomendaciones.py
+git commit -m "feat: cada recomendación declara si borra, es irreversible o solo lista"
+```
+
+---
+
+### Task 5: El ahorro se mide del disco, no del código de salida
+
+**Archivos:**
+- Modificar: `web/src/hooks/useCleanupRunner.ts:168-172`
+- Modificar: `web/src/hooks/useCleanupRunner.test.ts`
+
+**Interfaces:**
+- Consume: `api.getSystemInfo()` (existente, trae `disk_usage.free`).
+- Produce: `cleanup:completed` pasa a emitir `{ command, space, estimado }`,
+  donde `space` es el delta medido y `estimado` el que traía la recomendación.
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```ts
+// Añadir a web/src/hooks/useCleanupRunner.test.ts
+//
+// Acreditar el ahorro por el código de salida es lo que hacía que un comando
+// no-op reportara "85 MB liberados". `rm -f` devuelve 0 tanto si borró todo
+// como si no borró nada, así que el exit code no prueba absolutamente nada
+// sobre el espacio.
+
+it('acredita el espacio realmente liberado, no el estimado', async () => {
+  // libre antes: 10 GB; después: 12 GB  →  se liberaron 2 GB
+  vi.mocked(api.getSystemInfo)
+    .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any)
+    .mockResolvedValueOnce({ disk_usage: { free: 12e9 } } as any);
+
+  const visto = vi.fn();
+  on('cleanup:completed', visto);
+  await ejecutarYCompletar({ command: 'rm -rf x', space: 99e9 }, 0);
+
+  expect(visto).toHaveBeenCalledWith(
+    expect.objectContaining({ space: 2e9, estimado: 99e9 }),
+  );
+});
+
+it('un comando que no libera nada acredita cero, no su estimación', async () => {
+  vi.mocked(api.getSystemInfo)
+    .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any)
+    .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any);
+
+  const visto = vi.fn();
+  on('cleanup:completed', visto);
+  await ejecutarYCompletar({ command: "rm -rf 'x/*'", space: 85e6 }, 0);
+
+  expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 0 }));
+});
+
+it('nunca acredita un ahorro negativo', async () => {
+  // Otro proceso escribió mientras corría la limpieza.
+  vi.mocked(api.getSystemInfo)
+    .mockResolvedValueOnce({ disk_usage: { free: 12e9 } } as any)
+    .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any);
+
+  const visto = vi.fn();
+  on('cleanup:completed', visto);
+  await ejecutarYCompletar({ command: 'rm -rf x', space: 1e9 }, 0);
+
+  expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 0 }));
+});
+```
+
+Adapta `ejecutarYCompletar` al helper que ya use ese fichero de tests para
+encolar un trabajo y disparar `terminal:exited` con un código.
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+cd web && npm test -- --run src/hooks/useCleanupRunner.test.ts
+```
+Esperado: FAIL, se acredita `job.space`.
+
+- [ ] **Paso 3: Mide antes y después**
+
+En `useCleanupRunner.ts`, guarda el espacio libre al encolar el trabajo y
+compáralo al terminar:
+
+```ts
+// Antes de lanzar el comando (donde hoy se llama a api.createTerminal):
+const libreAntes = await api.getSystemInfo()
+  .then(i => i.disk_usage?.free ?? null)
+  .catch(() => null);
+
+// En finishActiveJob, dentro de la rama `code === 0`:
+// El código de salida no dice nada sobre el espacio: `rm -f` devuelve 0
+// tanto si borró todo como si no borró nada. Se mide el disco.
+let liberado = job.space;
+if (libreAntes != null) {
+  const libreDespues = await api.getSystemInfo()
+    .then(i => i.disk_usage?.free ?? null)
+    .catch(() => null);
+  if (libreDespues != null) {
+    liberado = Math.max(0, libreDespues - libreAntes);
+  }
+}
+emit('cleanup:completed', { command: job.command, space: liberado,
+                            estimado: job.space });
+```
+
+Guarda `libreAntes` en el objeto del trabajo, junto a `command` y `space`.
+
+- [ ] **Paso 4: Verifica**
+
+```bash
+cd web && npm test -- --run && npm run check
+```
+
+- [ ] **Paso 5: Commit**
+
+```bash
+git add web/src/hooks/useCleanupRunner.ts web/src/hooks/useCleanupRunner.test.ts
+git commit -m "fix(web): acreditar el espacio medido del disco, no el estimado"
+```
+
+---
+
+## Fase 3 — Un solo motor
+
+### Task 6: Fusionar las dos `generate_recommendations` con `id` estable
+
+**Archivos:**
+- Modificar: `disk_analyzer_core.py:561` (única implementación, con `id`)
+- Modificar: `disk_analyzer.py:888` (pasa a delegar)
+- Crear: `tests/test_motor_unico.py`
+
+**Interfaces:**
+- Consume: `comandos.borrar_contenido/borrar_rutas` (Task 1),
+  `'efecto'` (Task 4).
+- Produce: cada recomendación gana `'id'`, un slug estable
+  (`'logs'`, `'homebrew'`, `'vscode'`, `'npm'`, `'simuladores'`,
+  `'descargas_antiguas'`, `'docker'`, `'cache_general'`, `'archivos_gigantes'`).
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```python
+# tests/test_motor_unico.py
+"""La CLI y la web tienen que ver las mismas recomendaciones.
+
+Hoy hay dos copias: `disk_analyzer_core.py:561` la usa la web y
+`disk_analyzer.py:888` la usan la CLI y la app de bandeja. La app de bandeja
+ejecuta `disk_analyzer.py`, así que la barra y la web pueden recomendar cosas
+distintas del mismo disco.
+
+Además, ninguna recomendación tiene identificador estable: `type` es una cadena
+de display en español y ya difiere entre copias ('Cache de Simuladores' contra
+'Cache de Simuladores iOS'). Sin `id` no se puede configurar nada.
+"""
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer import DiskAnalyzer
+from disk_analyzer_core import DiskAnalyzerCore
+
+
+def _preparar(obj, cache_locations, docker_stats=None):
+    obj.cache_locations = list(cache_locations)
+    obj.large_files = []
+    obj.docker_stats = docker_stats
+    return obj.generate_recommendations()
+
+
+def test_las_dos_interfaces_recomiendan_lo_mismo():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    locs, docker = core.cache_locations, core.docker_stats
+
+    del_core = _preparar(DiskAnalyzerCore('.'), locs, docker)
+    del_cli = _preparar(DiskAnalyzer('.'), locs, docker)
+
+    assert [r['id'] for r in del_core] == [r['id'] for r in del_cli]
+    assert [r['tier'] for r in del_core] == [r['tier'] for r in del_cli]
+    assert [r['command'] for r in del_core] == [r['command'] for r in del_cli]
+
+
+def test_los_ids_son_estables_y_no_son_texto_de_interfaz():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    for r in core.generate_recommendations():
+        ident = r.get('id', '')
+        assert ident, f"{r.get('type')} no tiene id"
+        assert ident.islower() and ' ' not in ident, (
+            f"{ident!r} parece texto de interfaz, no un identificador"
+        )
+        assert ident.isascii(), f"{ident!r} no es ascii: no sirve como clave"
+
+
+def test_los_ids_no_se_repiten():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    ids = [r['id'] for r in core.generate_recommendations()]
+    assert len(ids) == len(set(ids)), f"ids duplicados: {ids}"
+```
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+venv-web/bin/python -m pytest tests/test_motor_unico.py -v
+```
+Esperado: FAIL, no existe `id` y las dos listas difieren.
+
+- [ ] **Paso 3: Añade `id` a cada recomendación del core**
+
+En `disk_analyzer_core.py:561`, añade `'id': '<slug>'` a cada
+`recommendations.append({...})`, con los slugs de la sección *Interfaces*.
+
+- [ ] **Paso 4: Haz que la CLI delegue**
+
+Sustituye el cuerpo entero de `generate_recommendations` en
+`disk_analyzer.py:888` por una delegación. Antes de escribirlo, **lee las dos
+implementaciones y anota las reglas que solo existen en la de la CLI** (Xcode
+DerivedData, runtimes de simulador, VMs). Esas reglas se **mueven al core** con
+su propio `id`; no se pierden.
+
+```python
+    def generate_recommendations(self) -> List[Dict]:
+        """Delegado en el motor compartido.
+
+        Antes había aquí una segunda implementación de los mismos niveles, que
+        ya había divergido de la del core: la web recomendaba una cosa y la app
+        de bandeja otra sobre el mismo disco, porque la bandeja ejecuta este
+        fichero.
+        """
+        from disk_analyzer_core import DiskAnalyzerCore
+        prestado = DiskAnalyzerCore(str(self.start_path))
+        prestado.cache_locations = self.cache_locations
+        prestado.large_files = self.large_files
+        prestado.docker_stats = self.docker_stats
+        return prestado.generate_recommendations()
+```
+
+Verifica el nombre real del atributo de ruta de `DiskAnalyzer` antes de usar
+`self.start_path`.
+
+- [ ] **Paso 5: Verifica que la suite entera sigue verde**
+
+```bash
+venv-web/bin/python -m pytest tests/ -q
+```
+Esperado: todo en verde. Si `tests/test_engine_characterization.py` falla,
+compara el fallo con las reglas que moviste: puede estar anclando una
+recomendación que solo existía en la CLI.
+
+- [ ] **Paso 6: Commit**
+
+```bash
+git add disk_analyzer.py disk_analyzer_core.py tests/test_motor_unico.py
+git commit -m "refactor: una sola definición de los niveles de limpieza"
+```
+
+---
+
+## Fase 4 — Las reglas que faltan
+
+### Task 7: Docker sin escaneo completo, `~/Library/Caches` y papelera
+
+**Archivos:**
+- Modificar: `disk_analyzer_core.py` (`generate_recommendations`)
+- Crear: `tests/test_reglas_nuevas.py`
+
+**Contexto medido:** las cachés de la máquina de desarrollo suman 101,85 GB,
+pero solo se recomiendan 17,6 y solo 4,01 son de nivel 1. Se quedan fuera Docker
+(39,6 GB), `~/Library/Caches` (21,4 GB) y la papelera. La regla de Docker
+**solo necesita `docker system df`**, que tarda segundos: hoy no aparece en la
+bandeja porque nadie rellena `docker_stats` en ese camino.
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```python
+# tests/test_reglas_nuevas.py
+"""Las reglas que dejaban fuera el 80% de lo encontrado."""
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer_core import DiskAnalyzerCore
+from analyzer import cache_types
+
+GB = 1024 ** 3
+
+
+def _core_con(locs, docker=None):
+    core = DiskAnalyzerCore('.')
+    core.cache_locations = locs
+    core.large_files = []
+    core.docker_stats = docker
+    return core
+
+
+def test_las_caches_de_library_se_recomiendan():
+    """21,4 GB reales en la máquina de desarrollo, sin ninguna regla."""
+    import os
+    ruta = os.path.expanduser('~/Library/Caches')
+    core = _core_con([{'type': cache_types.GENERAL, 'path': ruta,
+                       'size': 21 * GB}])
+    ids = {r['id'] for r in core.generate_recommendations()}
+    assert 'caches_de_apps' in ids
+
+
+def test_la_papelera_se_recomienda():
+    import os
+    ruta = os.path.expanduser('~/.Trash')
+    core = _core_con([{'type': cache_types.TRASH, 'path': ruta,
+                       'size': 3 * GB}])
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'papelera' in recs
+    assert recs['papelera']['tier'] == 1, "vaciar la papelera es seguro"
+
+
+def test_docker_aparece_solo_con_docker_stats():
+    """No debe exigir un escaneo del disco completo: `docker system df` basta."""
+    core = _core_con([], docker={'available': True, 'reclaimable': 39 * GB})
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'docker' in recs
+    assert recs['docker']['efecto'] == 'irreversible'
+
+
+def test_las_caches_de_apps_no_incluyen_datos_de_usuario():
+    """La regla no puede arrastrar nada que no sea caché."""
+    from analyzer.protection import puede_borrarse
+    import os
+    core = _core_con([{'type': cache_types.GENERAL,
+                       'path': os.path.expanduser('~/Library/Caches'),
+                       'size': 21 * GB}])
+    for r in core.generate_recommendations():
+        if r['id'] == 'caches_de_apps':
+            assert puede_borrarse(os.path.expanduser('~/Library/Caches'))
+```
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+venv-web/bin/python -m pytest tests/test_reglas_nuevas.py -v
+```
+Esperado: FAIL, no existen `caches_de_apps` ni `papelera`.
+
+- [ ] **Paso 3: Añade las reglas al core**
+
+En `generate_recommendations`, junto a las de nivel 2:
+
+```python
+        # Cachés de aplicaciones: 21,4 GB medidos en la máquina de desarrollo y
+        # ninguna regla los miraba. Nivel 2 y no 1 porque algunas apps guardan
+        # ahí cosas que tardan en regenerarse (índices, miniaturas).
+        app_caches = [l for l in self.cache_locations
+                      if l['type'] == cache_types.GENERAL
+                      and 'Library/Caches' in l['path']]
+        if app_caches and sum(l['size'] for l in app_caches) > 500 * MB:
+            total = sum(l['size'] for l in app_caches)
+            recommendations.append({
+                'id': 'caches_de_apps', 'tier': 2, 'priority': 'Moderado',
+                'type': 'Cachés de aplicaciones',
+                'description': f'{self.format_size(total)} en ~/Library/Caches',
+                'space': total, 'efecto': 'borra',
+                'command': comandos.borrar_contenido(
+                    [l['path'] for l in app_caches])})
+```
+
+Y junto a las de nivel 1:
+
+```python
+        # La papelera: espacio que el usuario ya decidió tirar. Nivel 1 sin
+        # discusión, y además es lo único que hace que "mover a la papelera"
+        # libere algo de verdad en el mismo volumen.
+        papelera = [l for l in self.cache_locations
+                    if l['type'] == cache_types.TRASH]
+        if papelera and sum(l['size'] for l in papelera) > 100 * MB:
+            total = sum(l['size'] for l in papelera)
+            recommendations.append({
+                'id': 'papelera', 'tier': 1, 'priority': 'Seguro',
+                'type': 'Papelera',
+                'description': f'{self.format_size(total)} ya en la papelera',
+                'space': total, 'efecto': 'borra',
+                'command': comandos.borrar_contenido(
+                    [l['path'] for l in papelera])})
+```
+
+- [ ] **Paso 4: Rellena `docker_stats` en el camino de la bandeja**
+
+`docker_stats` viene de `docker system df` y tarda segundos, pero hoy solo se
+rellena en el escaneo completo. Localiza dónde se puebla (busca
+`docker_stats` en `disk_analyzer.py`) y llámalo también en el camino que usa
+`--export`, para que la bandeja lo tenga. Si Docker no está instalado, el
+atributo queda en `None` y la regla no dispara: no hace falta nada más.
+
+- [ ] **Paso 5: Verifica**
+
+```bash
+venv-web/bin/python -m pytest tests/ -q
+```
+
+- [ ] **Paso 6: Commit**
+
+```bash
+git add disk_analyzer_core.py disk_analyzer.py tests/test_reglas_nuevas.py
+git commit -m "feat: reglas para cachés de apps, papelera y Docker sin escaneo completo"
+```
+
+---
+
+## Fase 5 — El puerto
+
+### Task 8: Puerto efímero y no reutilizar servidores ajenos
+
+**Archivos:**
+- Modificar: `desktop/src-tauri/src/servidor.rs`
+- Test: módulo `#[cfg(test)]` dentro del mismo fichero
+
+**Contexto:** hoy `PUERTO` es `8000` fijo y `puerto_ocupado()` solo comprueba
+que *algo* acepte TCP ahí. Con un Django o un Rails en el 8000, "Abrir
+analizador completo" abre esa aplicación diciendo que es el analizador. El 8000
+además es un puerto muy disputado, y la app abre el navegador ella misma, así
+que el número es invisible para el usuario: no hay ninguna razón para fijarlo.
+`make web` se queda con el 8000, que es su comportamiento documentado.
+
+- [ ] **Paso 1: Escribe los tests que fallan**
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::TcpListener;
+
+    #[test]
+    fn pide_un_puerto_libre_distinto_del_8000() {
+        let p = puerto_libre().expect("debería conseguir un puerto");
+        assert_ne!(p, 8000, "el 8000 está muy disputado: Django, Rails, etc.");
+        assert!(p >= 1024, "no se piden puertos privilegiados");
+    }
+
+    #[test]
+    fn dos_llamadas_no_devuelven_el_mismo_puerto_ocupado() {
+        let a = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let ocupado = a.local_addr().unwrap().port();
+        // Mientras `a` siga vivo, nadie debe proponer ese puerto.
+        for _ in 0..20 {
+            assert_ne!(puerto_libre().unwrap(), ocupado);
+        }
+    }
+
+    #[test]
+    fn no_reutiliza_un_servidor_ajeno() {
+        // Alguien ocupa un puerto sin ser nuestro servidor.
+        let ajeno = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+        let puerto = ajeno.local_addr().unwrap().port();
+        let servidor = Servidor::new();
+        assert!(
+            !servidor.es_nuestra_instancia(puerto),
+            "abrir el navegador en un servidor ajeno lo presenta como nuestro"
+        );
+    }
+}
+```
+
+- [ ] **Paso 2: Ejecútalos para verificar que fallan**
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+cargo test --manifest-path desktop/src-tauri/Cargo.toml --lib servidor
+```
+Esperado: FAIL, `puerto_libre` y `es_nuestra_instancia` no existen.
+
+- [ ] **Paso 3: Implementa el puerto efímero**
+
+```rust
+/// Pide al sistema un puerto libre.
+///
+/// Atar el 0 hace que el kernel asigne uno sin usar; se suelta acto seguido y
+/// se le pasa al servidor. Queda una ventana mínima en la que otro proceso
+/// podría cogerlo, y por eso quien llama reintenta.
+///
+/// El 8000 fijo que había antes es un puerto muy disputado (Django, Rails,
+/// http.server). Y como la app abre el navegador ella misma, el número nunca
+/// lo ve el usuario: fijarlo solo servía para chocar.
+fn puerto_libre() -> Result<u16, String> {
+    let l = std::net::TcpListener::bind(("127.0.0.1", 0))
+        .map_err(|e| format!("no se pudo pedir un puerto libre: {e}"))?;
+    let p = l
+        .local_addr()
+        .map_err(|e| format!("no se pudo leer el puerto asignado: {e}"))?
+        .port();
+    drop(l);
+    Ok(p)
+}
+```
+
+- [ ] **Paso 4: Reutiliza solo lo nuestro**
+
+```rust
+impl Servidor {
+    /// Si el puerto lo ocupa el servidor que arrancamos nosotros.
+    ///
+    /// La versión anterior solo comprobaba que *algo* aceptara TCP en el 8000,
+    /// así que un Django del usuario se abría en el navegador como si fuera el
+    /// analizador. Ahora se exige que sea nuestra instancia registrada y que su
+    /// proceso siga vivo.
+    pub fn es_nuestra_instancia(&self, puerto: u16) -> bool {
+        let guard = self.instancia.lock().unwrap();
+        match guard.as_ref() {
+            Some(inst) => {
+                inst.puerto == puerto
+                    && unsafe { libc::kill(inst.pid, 0) } == 0
+                    && acepta(puerto)
+            }
+            None => false,
+        }
+    }
+}
+```
+
+Añade `puerto: u16` al struct `Instancia`, renombra `puerto_ocupado()` a
+`acepta(puerto: u16) -> bool` recibiendo el puerto, y en `abrir`:
+
+- si `es_nuestra_instancia(inst.puerto)` → devuelve la URL guardada;
+- si no → **siempre** arranca uno nuevo en `puerto_libre()`, sin mirar el 8000;
+- borra por completo la rama que abría la URL a secas cuando el puerto estaba
+  ocupado por otro.
+
+- [ ] **Paso 5: Verifica**
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+cargo clippy --manifest-path desktop/src-tauri/Cargo.toml --all-targets -- -D warnings
+cargo test --manifest-path desktop/src-tauri/Cargo.toml
+```
+
+- [ ] **Paso 6: Verificación manual**
+
+```bash
+python3 -m http.server 8000 &     # ocupa el 8000 con algo ajeno
+open "/Applications/Disk Use Analyzer.app"
+```
+Pulsa "Abrir analizador completo". Esperado: se abre **el analizador**, en un
+puerto distinto del 8000, no el `http.server`. Después: `kill %1`.
+
+- [ ] **Paso 7: Commit**
+
+```bash
+git add desktop/src-tauri/src/servidor.rs
+git commit -m "fix(desktop): puerto efímero y no abrir servidores ajenos como propios"
+```
+
+---
+
+## Fuera del alcance de este plan
+
+Declarado, no olvidado:
+
+- **La ventana nativa con gráficas propias.** Dos revisiones adversariales
+  independientes concluyeron que sería el tercer stack de visualización del
+  repositorio (el informe del CLI ya embebe Plotly, la web también) para mostrar
+  peor lo que "Abrir analizador completo" ya entrega. Se descarta hasta tener
+  una razón que no sea estética.
+- **El catálogo declarativo y los cuatro ejes de configuración.** Los `id`
+  estables del Task 6 son exactamente la migración que haría falta si algún día
+  se construye; hasta entonces no se paga el edificio. De los cuatro ejes, tres
+  fueron calificados de teatro por la revisión de producto; el único que se
+  gana el sitio —activar/desactivar categorías— cabe como casillas en el diálogo
+  de confirmación, sin pantalla de ajustes.
+- **El botón "Liberar lo seguro" en el menú de la bandeja.** Es lo que originó
+  todo esto, y sigue siendo deseable — pero construirlo antes de la Fase 1 sería
+  poner un botón de un clic encima de una inyección de shell. Tendrá su propio
+  plan cuando esto esté verde.
+- **La semántica de papelera por nivel.** Queda pendiente de decisión: para las
+  invocaciones a herramientas no existe papelera posible, y mover ficheros a
+  `~/.Trash` en el mismo volumen no libera espacio hasta vaciarla. El campo
+  `efecto` del Task 4 es lo que permitirá decidirlo con datos.
+- **La Fase 0 de higiene del repositorio**, que sigue pendiente desde julio.
+
+## Autorrevisión
+
+**1. Cobertura de los hallazgos:** H1 → Task 1; H2 → Tasks 1 y 5; H3 → Task 3;
+H4 → Task 2; H5 → Task 8. La duplicación del motor → Task 6. El hueco de 101 GB
+contra 4 GB recomendados → Task 7.
+
+**2. Marcadores:** ninguno. Las notas del tipo "verifica el nombre real de la
+variable antes de sustituir" son deliberadas: los nombres exactos de esos
+atributos no se pudieron confirmar al escribir el plan y respetarlas evita un
+reemplazo a ciegas.
+
+**3. Consistencia de tipos:** `comandos.borrar_contenido/borrar_rutas` se
+definen en el Task 1 y se consumen en los Tasks 1, 6 y 7. `puede_borrarse` se
+define en el Task 2 y se consume en el Task 7. `'efecto'` se define en el Task 4
+y se consume en el Task 7. `'id'` se define en el Task 6 y se consume en el
+Task 7 y en los tests del 7. `nivelDe` es local al Task 3.
+
+**4. Riesgo principal:** el Task 6 toca la función de la que dependen los tests
+de caracterización. Por eso va después de las fases de seguridad: si hay que
+revertirlo, los arreglos críticos ya están dentro.

--- a/docs/superpowers/plans/README.md
+++ b/docs/superpowers/plans/README.md
@@ -7,8 +7,8 @@ cuál es la siguiente acción y cómo ejecutarla.
 
 ## Estado de un vistazo
 
-Última actualización: 20 de agosto de 2026. Tests: **151** (backend) + **69**
-(frontend) + **11** (app de bandeja, Rust) = **231**, los tres cableados al CI
+Última actualización: 23 de agosto de 2026. Tests: **247** (backend) + **85**
+(frontend) + **20** (app de bandeja, Rust) = **352**, los tres cableados al CI
 de GitHub Actions y a `make test`.
 
 | Fase | Alcance | Plan | Estado |
@@ -39,6 +39,48 @@ verificando cada push y cada pull request. Quedan:
    por corridas anteriores con `sudo`, y eso ya provocó un fallo real (un 500 al
    no poder escribir el log de agents).
 2. **Rebanadas B y C de la app de bandeja** (ver más abajo).
+
+## Saneamiento de la limpieza (23 de agosto de 2026)
+
+La maquinaria de limpieza tenía defectos serios que se descubrieron al planear
+acciones de limpieza en el menú de la bandeja. Se sanearon antes de construir
+encima, en [su propio plan](2026-08-21-saneamiento-limpieza.md) de 8 tasks.
+
+Lo que estaba roto, todo reproducido antes de escribir el plan:
+
+- **Inyección de shell:** las rutas se interpolaban sin escapar en cadenas que
+  se ejecutan con `sh -c`. Una carpeta llamada `x' ; rm -rf victim ; '` ejecutaba
+  comandos arbitrarios.
+- **Limpiezas que no limpiaban:** el glob iba dentro de las comillas, así que
+  `rm -rf 'dir/*'` salía con código 0 sin borrar nada — y la interfaz acreditaba
+  el ahorro por ese 0.
+- **`make clean-cache` borraba `~/Downloads` según el nombre del usuario.** El
+  clasificador miraba subcadenas de la ruta completa: un usuario `logan` tenía
+  su carpeta de Descargas clasificada como logs del sistema.
+- **La protección no protegía tus datos:** `~/Documents`, iCloud Drive y
+  `/Volumes` salían como borrables.
+- **La bandeja abría lo que hubiera en el puerto 8000** presentándolo como el
+  analizador.
+
+Lo que dejó, además de los arreglos: una **verja de borrado**
+(`puede_borrarse`) instalada en los tres caminos que borran, un `id` estable y
+un campo `efecto` (`borra` / `irreversible` / `solo_lista`) por recomendación,
+una sola definición de los niveles de riesgo, y el ahorro medido del disco en
+vez de deducido del código de salida. Las invariantes de seguridad están en
+`CLAUDE.md`.
+
+**Lo que queda para un plan siguiente**, y por qué se dejó fuera:
+
+- El campo `efecto` está construido y **ningún componente lo lee todavía**, así
+  que las recomendaciones que solo listan siguen ofreciéndose con botón.
+- El número de cabecera sigue inflado: suma cachés que nunca se ofrecen.
+- `nivelDe` solo se usa en `CleanupWizard`; los otros tres botones por lotes
+  leen `tier` en crudo.
+- Dos reglas (`node_modules_huerfano`, `git_pack_files`) no pueden dispararse
+  nunca: sus rutas están en `IGNORE_PATTERNS`, así que el escáner no las ve.
+- El botón "Liberar lo seguro" en el menú, la configuración de qué es seguro y
+  la ventana nativa: lo que originó todo esto, aplazado a propósito hasta que
+  la base fuera segura.
 
 ## Trabajo aparte: app de bandeja de macOS
 

--- a/tests/test_cache_labels.py
+++ b/tests/test_cache_labels.py
@@ -16,8 +16,21 @@ def test_every_recommendation_filter_label_is_producible():
     """Any label the recommendation logic filters on must be a real label."""
     known = set(cache_types.ALL_LABELS)
     core = DiskAnalyzerCore(".")
+    home = str(Path.home())
+    # logs/vscode/npm/papelera are scoped by path as well as by `type` (Task
+    # 4 of the final review pass, see disk_analyzer_core.py) -- an arbitrary
+    # '/fake/<label>' path no longer satisfies them, so those four need a
+    # realistic path to still fire here. Every other label keeps the
+    # arbitrary fake path: this test only needs recs non-empty, not every
+    # label to fire a recommendation on its own.
+    rutas_conocidas = {
+        cache_types.LOGS: f'{home}/Library/Logs',
+        cache_types.VSCODE: f'{home}/Library/Application Support/Code/Cache',
+        cache_types.NPM: f'{home}/.npm',
+        cache_types.TRASH: f'{home}/.Trash',
+    }
     core.cache_locations = [
-        {"path": f"/fake/{label}", "size": 5 * GB, "type": label}
+        {"path": rutas_conocidas.get(label, f"/fake/{label}"), "size": 5 * GB, "type": label}
         for label in known
     ]
     recs = core.generate_recommendations()

--- a/tests/test_clean_cache_verja.py
+++ b/tests/test_clean_cache_verja.py
@@ -1,0 +1,104 @@
+"""`clean_cache` borraba `~/Downloads` según cómo se llamara el usuario.
+
+Dos defectos distintos, verificados por separado:
+
+1. `analyzer/cache_types.py::classify` comparaba subcadenas contra la ruta
+   completa en minúsculas, nombre de usuario incluido. Con un usuario
+   'logan', `~/Downloads` clasificaba como 'Logs del Sistema' -- una
+   etiqueta en `SAFE_TO_CLEAN`. Con 'nicode', como 'VS Code Cache'. Con
+   'anode', como 'NPM Cache'. Las tres están en `SAFE_TO_CLEAN`.
+2. `DiskAnalyzer.clean_cache` (disk_analyzer.py) borraba con
+   `path.rglob('*') + unlink()` -- permanente, sin papelera -- para
+   cualquier `cache_loc` cuyo `type` estuviera en `SAFE_TO_CLEAN`, sin
+   volver a consultar `protection.puede_borrarse`. Es la misma verja que
+   `analyzer/comandos.py` instala para todo comando generado (Task 7); este
+   método borra directamente, así que quedaba fuera de ella -- "una verja
+   construida y no instalada", en la puerta de al lado.
+
+Con los dos defectos activos a la vez, un usuario llamado 'logan' que
+ejecutara `make clean-cache` perdía su carpeta de Descargas entera.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, '.')
+
+from analyzer import cache_types
+from disk_analyzer import DiskAnalyzer
+
+
+# -- Dirección 1: classify() no debe dejar que el nombre de usuario decida --
+
+def test_downloads_no_se_clasifica_como_logs_con_usuario_logan():
+    assert cache_types.classify(Path('/Users/logan/Downloads')) == cache_types.DOWNLOADS
+
+
+def test_downloads_no_se_clasifica_como_vscode_con_usuario_nicode():
+    assert cache_types.classify(Path('/Users/nicode/Downloads')) == cache_types.DOWNLOADS
+
+
+def test_downloads_no_se_clasifica_como_npm_con_usuario_anode():
+    assert cache_types.classify(Path('/Users/anode/Downloads')) == cache_types.DOWNLOADS
+
+
+def test_las_clasificaciones_legitimas_siguen_funcionando():
+    """El fix de la dirección 1 no puede romper la clasificación real bajo
+    el propio $HOME de quien corre el test."""
+    home = Path.home()
+    assert cache_types.classify(home / 'Library/Logs') == cache_types.LOGS
+    assert cache_types.classify(home / '.npm') == cache_types.NPM
+    assert cache_types.classify(home / 'Library/Application Support/Code/Cache') == cache_types.VSCODE
+    assert cache_types.classify(home / 'Library/Developer/Xcode/DerivedData') == cache_types.XCODE
+    assert cache_types.classify(home / '.Trash') == cache_types.TRASH
+
+
+# -- Dirección 2: clean_cache debe consultar la verja antes de borrar --
+
+def test_clean_cache_se_niega_a_borrar_una_ruta_que_la_verja_prohibe(tmp_path):
+    """Reproduce el escenario: una ruta que classify() (con el bug) habría
+    marcado como segura, pero que protection.puede_borrarse rechaza porque
+    cae bajo una ruta de datos de usuario (~/Downloads vive bajo '~', que
+    está en RUTAS_DE_DATOS_DE_USUARIO y no tiene excepción)."""
+    analyzer = DiskAnalyzer('.')
+    ruta_prohibida = '/Users/logan/Downloads'
+    analyzer.cache_locations = [
+        {'path': ruta_prohibida, 'size': 1000, 'type': cache_types.LOGS},
+    ]
+
+    with patch('disk_analyzer.Path.exists', return_value=True), \
+         patch('disk_analyzer.Path.is_file', return_value=False), \
+         patch('disk_analyzer.Path.rglob') as mock_rglob:
+        analyzer.clean_cache(dry_run=False)
+        mock_rglob.assert_not_called()
+
+
+def test_clean_cache_borra_una_cache_legitima_que_la_verja_permite():
+    """Simétrico: si la verja SÍ permite la ruta, clean_cache debe seguir
+    intentando borrarla -- que el fix no se convierta en un no-op total."""
+    home = str(Path.home())
+    analyzer = DiskAnalyzer('.')
+    ruta_permitida = f'{home}/Library/Caches/algo'
+    analyzer.cache_locations = [
+        {'path': ruta_permitida, 'size': 1000, 'type': cache_types.LOGS},
+    ]
+
+    with patch('disk_analyzer.Path.exists', return_value=True), \
+         patch('disk_analyzer.Path.is_file', return_value=False), \
+         patch('disk_analyzer.Path.rglob', return_value=[]) as mock_rglob:
+        analyzer.clean_cache(dry_run=False)
+        mock_rglob.assert_called_once()
+
+
+def test_clean_cache_dry_run_tambien_respeta_la_verja(capsys):
+    """El dry-run reporta 'se liberaría' sin borrar nada -- pero no debe
+    contar una ruta prohibida como espacio recuperable."""
+    analyzer = DiskAnalyzer('.')
+    analyzer.cache_locations = [
+        {'path': '/Users/logan/Downloads', 'size': 5_000_000, 'type': cache_types.LOGS},
+    ]
+    with patch('disk_analyzer.Path.exists', return_value=True):
+        analyzer.clean_cache(dry_run=True)
+    salida = capsys.readouterr().out
+    assert 'Omitido' in salida
+    assert '0.00 B' in salida or '0 B' in salida

--- a/tests/test_cleanup_api.py
+++ b/tests/test_cleanup_api.py
@@ -115,10 +115,10 @@ class TestCleanupExecute:
                 pass
 
         monkeypatch.setattr(disk_analyzer_web, "DiskAnalyzerCore", FakeAnalyzer)
-        # _perform_cleanup_deletes now calls the shared analyzer.protection.is_protected_path
-        # free function directly (imported into this module's namespace), instead of a
-        # DiskAnalyzerCore instance method -- patch it at its new call site.
-        monkeypatch.setattr(disk_analyzer_web, "is_protected_path", lambda path: path.startswith("/System"))
+        # _perform_cleanup_deletes now calls the shared analyzer.protection.puede_borrarse
+        # free function directly (imported into this module's namespace), instead of the
+        # weaker is_protected_path OS-blacklist check -- patch it at its new call site.
+        monkeypatch.setattr(disk_analyzer_web, "puede_borrarse", lambda path: not path.startswith("/System"))
         resp = self.client.post(
             "/api/cleanup/execute",
             json={"paths": [str(tmp_path)], "dry_run": False},
@@ -131,3 +131,51 @@ class TestCleanupExecute:
         # The protected path must be skipped, reported as error, never deleted
         error_paths = [e["path"] for e in body["errors"]]
         assert any("/System" in p for p in error_paths)
+
+    def test_execute_refuses_downloads_and_coresimulator_even_though_not_os_protected(self, tmp_path, monkeypatch):
+        """Revisión final, hallazgo 2: is_protected_path (lista negra del
+        sistema operativo) devuelve False para ~/Downloads y para
+        ~/Library/Developer/CoreSimulator/Devices -- ninguna de las dos es
+        "del sistema". Antes de este fix, _perform_cleanup_deletes solo
+        miraba is_protected_path, así que las borraba igual. Ahora tiene
+        que consultar puede_borrarse (la whitelist real), que sí las
+        rechaza. Este test usa rutas reales (no monkeypatchea
+        puede_borrarse) para probar el filtro de verdad, con
+        shutil.rmtree parcheado para no depender de que existan de verdad
+        en la máquina que corre el test."""
+        import os
+        home = os.path.expanduser("~")
+        downloads = home + "/Downloads"
+        coresim = home + "/Library/Developer/CoreSimulator/Devices"
+        victim = tmp_path / "cache_dir"
+        victim.mkdir()
+        (victim / "junk.bin").write_bytes(b"x" * 1024)
+
+        class FakeAnalyzer:
+            def __init__(self, path):
+                self.cache_locations = [
+                    {"path": str(victim), "size": 1024, "type": "Cache General"},
+                    {"path": downloads, "size": 999, "type": "Downloads"},
+                    {"path": coresim, "size": 999, "type": "Cache General"},
+                ]
+
+            def find_cache_locations(self):
+                pass
+
+        monkeypatch.setattr(disk_analyzer_web, "DiskAnalyzerCore", FakeAnalyzer)
+        monkeypatch.setattr(disk_analyzer_web.shutil, "rmtree", lambda p: None)
+        monkeypatch.setattr(disk_analyzer_web.Path, "is_dir", lambda self: True)
+        monkeypatch.setattr(disk_analyzer_web.Path, "is_file", lambda self: False)
+
+        resp = self.client.post(
+            "/api/cleanup/execute",
+            json={"paths": [str(tmp_path)], "dry_run": False},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        deleted_paths = [d["path"] for d in body["deleted"]]
+        error_paths = [e["path"] for e in body["errors"]]
+        assert downloads not in deleted_paths, "~/Downloads no debe borrarse nunca"
+        assert coresim not in deleted_paths, "CoreSimulator Devices no debe borrarse nunca"
+        assert downloads in error_paths
+        assert coresim in error_paths

--- a/tests/test_comandos.py
+++ b/tests/test_comandos.py
@@ -86,3 +86,90 @@ def test_la_raiz_nunca_genera_comando():
     """Salvaguarda de último recurso: nada construye un borrado de `/`."""
     assert borrar_contenido(["/"]) == ""
     assert borrar_rutas(["/"]) == ""
+
+
+# -- Ronda de arreglo 1: tres sitios que el grep del brief no cazaba porque
+# ninguno usa `rm -rf`. Misma clase de bug (interpolación sin escapar en un
+# 'command' que se ejecuta con sh -c), así que entran en el alcance del task. --
+
+import shlex
+from pathlib import Path
+
+from disk_analyzer import DiskAnalyzer
+
+
+def test_conda_env_remove_escapa_el_nombre_del_entorno():
+    """disk_analyzer.py:723 interpolaba `env_name` sin comillas ni escapado.
+
+    `env_name` es el nombre de un subdirectorio de un envs-dir de conda,
+    tan controlable como cualquier otra ruta del escaneo. Antes del arreglo
+    ni siquiera había comillas que romper: `conda env remove -n {env_name}`
+    era interpolación directa.
+    """
+    analyzer = DiskAnalyzer(".")
+    home = str(Path.home())
+    base = f"{home}/miniconda3/envs"
+    env_name = "x'; touch pwned; echo '"
+    dir_path = f"{base}/{env_name}"
+
+    analyzer.directory_sizes[dir_path] = 10 * 1024 * 1024
+    analyzer.large_files = [
+        {"path": f"{dir_path}/lib/x", "size": 1024, "age_days": 200}
+    ]
+
+    recs = analyzer.detect_smart_recommendations()
+    conda_recs = [r for r in recs if r["type"] == "Entorno Conda Obsoleto"]
+    assert conda_recs, "la recomendación de conda no se generó (fixture desalineado)"
+
+    cmd = conda_recs[0]["command"]
+    # Si el nombre volviera a interpolarse sin escapar, `shlex.split` partiría
+    # el comando en piezas extra en vez de tratar el nombre como un solo token.
+    assert shlex.split(cmd) == ["conda", "env", "remove", "-n", env_name]
+
+
+def test_git_gc_escapa_la_ruta_del_repo():
+    """disk_analyzer.py:813 usaba comillas simples manuales sin escapar
+    el contenido -- el mismo patrón exacto del bug original.
+    """
+    analyzer = DiskAnalyzer(".")
+    repo_path = "/tmp/x' ; touch pwned ; echo '/repo"
+    analyzer.large_files = [
+        {
+            "path": f"{repo_path}/.git/objects/pack/pack-abc.pack",
+            "size": 200 * 1024 * 1024,
+        }
+    ]
+
+    recs = analyzer.detect_smart_recommendations()
+    git_recs = [r for r in recs if r["type"] == "Git Pack Files Grandes"]
+    assert git_recs, "la recomendación de git gc no se generó (fixture desalineado)"
+
+    cmd = git_recs[0]["command"]
+    assert shlex.split(cmd) == ["cd", repo_path, "&&", "git", "gc", "--aggressive"]
+
+
+def test_du_sh_otros_escapa_la_ruta_y_de_verdad_lista_el_contenido():
+    """disk_analyzer.py:3974 interpolaba `path` dentro de comillas dobles, que
+    no neutralizan `$(...)`: dentro de comillas dobles POSIX, la sustitución
+    de comandos SÍ se expande (a diferencia de las comillas simples). Con la
+    plantilla vieja, un nombre de carpeta con `$(touch pwned)` ejecutaba
+    `touch pwned` al construir el argumento de `du`, antes incluso de que
+    `du` se ejecutara.
+    """
+    analyzer = DiskAnalyzer(".")
+    with tempfile.TemporaryDirectory() as box:
+        peligroso = os.path.join(box, "x$(touch pwned)y")
+        os.makedirs(peligroso)
+        open(os.path.join(peligroso, "a"), "w").write("x" * 1024)
+
+        commands = analyzer._generate_category_cleanup_commands(
+            "Otros", [(peligroso, 2 * 1024 * 1024 * 1024)]
+        )
+        assert commands, "no se generó comando para 'Otros' (fixture desalineado)"
+        cmd = commands[0]["command"]
+
+        _ejecutar(cmd, cwd=box)
+
+        assert not os.path.exists(os.path.join(box, "pwned")), (
+            "se ejecutó un comando arbitrario embebido en el nombre de la carpeta"
+        )

--- a/tests/test_comandos.py
+++ b/tests/test_comandos.py
@@ -1,0 +1,88 @@
+"""El constructor de comandos de borrado.
+
+Los dos fallos que estos tests fijan estaban en producción y se reprodujeron:
+una carpeta con un apóstrofe en el nombre ejecutaba comandos arbitrarios, y el
+glob entrecomillado hacía que el borrado no borrara nada y saliera con éxito.
+"""
+import os
+import subprocess
+import tempfile
+
+from analyzer.comandos import borrar_contenido, borrar_rutas, escapar
+
+
+def _ejecutar(cmd: str, cwd: str) -> int:
+    return subprocess.run(["/bin/sh", "-c", cmd], cwd=cwd,
+                          capture_output=True).returncode
+
+
+def test_una_ruta_maliciosa_no_ejecuta_comandos_extra():
+    """El nombre de una carpeta no puede ser código.
+
+    Reproducido en producción: `x' ; rm -rf victim ; touch pwned '` con la
+    plantilla vieja generaba tres comandos y borraba una carpeta ajena.
+    """
+    with tempfile.TemporaryDirectory() as box:
+        os.makedirs(os.path.join(box, "victima"))
+        malicioso = os.path.join(box, "x' ; rm -rf victima ; touch pwned '")
+        os.makedirs(malicioso)
+
+        _ejecutar(borrar_contenido([malicioso]), cwd=box)
+
+        assert os.path.isdir(os.path.join(box, "victima")), (
+            "el nombre de otra carpeta consiguió borrar la víctima"
+        )
+        assert not os.path.exists(os.path.join(box, "pwned")), (
+            "se ejecutó un comando arbitrario embebido en el nombre"
+        )
+
+
+def test_borrar_contenido_borra_de_verdad():
+    """El glob tiene que quedar FUERA de las comillas o no expande.
+
+    Con `rm -rf 'dir/*'` el shell trata el asterisco como literal, `rm -f` sale
+    0 y no borra nada. La interfaz acreditaba el ahorro por ese 0.
+    """
+    with tempfile.TemporaryDirectory() as box:
+        objetivo = os.path.join(box, "cache")
+        os.makedirs(objetivo)
+        open(os.path.join(objetivo, "a.log"), "w").write("x")
+        open(os.path.join(objetivo, "b.log"), "w").write("x")
+
+        _ejecutar(borrar_contenido([objetivo]), cwd=box)
+
+        assert os.listdir(objetivo) == [], "el contenido sobrevivió al borrado"
+        assert os.path.isdir(objetivo), "borró el directorio, no su contenido"
+
+
+def test_borrar_rutas_borra_el_directorio_entero():
+    with tempfile.TemporaryDirectory() as box:
+        objetivo = os.path.join(box, "basura")
+        os.makedirs(objetivo)
+        _ejecutar(borrar_rutas([objetivo]), cwd=box)
+        assert not os.path.exists(objetivo)
+
+
+def test_escapar_sobrevive_al_viaje_de_ida_y_vuelta():
+    """Escapar y volver a parsear tiene que devolver la ruta original.
+
+    Es la propiedad que importa: da igual cómo se escape mientras el shell
+    reconstruya exactamente la ruta que le dimos, ni un carácter más.
+    """
+    import shlex
+    for peligro in ["a'b", "a b", "a;b", "a&&b", "a$(id)b", "a`id`b",
+                    "a\nb", "a*b", "a|b", "~/algo", "-rf"]:
+        assert shlex.split(escapar(peligro)) == [peligro]
+
+
+def test_una_ruta_vacia_no_produce_comando():
+    """Una ruta vacía convertiría `rm -rf ''/*` en algo impredecible."""
+    assert borrar_contenido([]) == ""
+    assert borrar_contenido([""]) == ""
+    assert borrar_rutas(["   "]) == ""
+
+
+def test_la_raiz_nunca_genera_comando():
+    """Salvaguarda de último recurso: nada construye un borrado de `/`."""
+    assert borrar_contenido(["/"]) == ""
+    assert borrar_rutas(["/"]) == ""

--- a/tests/test_comandos.py
+++ b/tests/test_comandos.py
@@ -12,6 +12,21 @@ import tempfile
 
 from analyzer.comandos import borrar_contenido, borrar_rutas, escapar
 
+# Desde que comandos.py instala la verja de protection.puede_borrarse
+# (Task 7), un sandbox bajo el directorio temporal del sistema
+# (tempfile.TemporaryDirectory() por defecto, que en macOS resuelve a
+# /private/var/folders/...) ya no genera comando: esa ruta está protegida a
+# propósito (ver tests/test_puede_borrarse.py::test_los_temporales_del_sistema_los_gestiona_macos).
+# Los tests de este módulo verifican el escapado de shell, no la política de
+# qué es borrable, así que el sandbox se crea dentro de una caché real y
+# conocida (~/Library/Caches) para que siga pasando la verja.
+_RAIZ_SANDBOX = os.path.expanduser("~/Library/Caches")
+
+
+def _sandbox():
+    os.makedirs(_RAIZ_SANDBOX, exist_ok=True)
+    return tempfile.TemporaryDirectory(dir=_RAIZ_SANDBOX)
+
 
 def _ejecutar(cmd: str, cwd: str) -> int:
     return subprocess.run(["/bin/sh", "-c", cmd], cwd=cwd,
@@ -24,7 +39,7 @@ def test_una_ruta_maliciosa_no_ejecuta_comandos_extra():
     Reproducido en producción: `x' ; rm -rf victim ; touch pwned '` con la
     plantilla vieja generaba tres comandos y borraba una carpeta ajena.
     """
-    with tempfile.TemporaryDirectory() as box:
+    with _sandbox() as box:
         os.makedirs(os.path.join(box, "victima"))
         malicioso = os.path.join(box, "x' ; rm -rf victima ; touch pwned '")
         os.makedirs(malicioso)
@@ -45,7 +60,7 @@ def test_borrar_contenido_borra_de_verdad():
     Con `rm -rf 'dir/*'` el shell trata el asterisco como literal, `rm -f` sale
     0 y no borra nada. La interfaz acreditaba el ahorro por ese 0.
     """
-    with tempfile.TemporaryDirectory() as box:
+    with _sandbox() as box:
         objetivo = os.path.join(box, "cache")
         os.makedirs(objetivo)
         open(os.path.join(objetivo, "a.log"), "w").write("x")
@@ -58,7 +73,7 @@ def test_borrar_contenido_borra_de_verdad():
 
 
 def test_borrar_rutas_borra_el_directorio_entero():
-    with tempfile.TemporaryDirectory() as box:
+    with _sandbox() as box:
         objetivo = os.path.join(box, "basura")
         os.makedirs(objetivo)
         _ejecutar(borrar_rutas([objetivo]), cwd=box)

--- a/tests/test_comandos.py
+++ b/tests/test_comandos.py
@@ -4,6 +4,8 @@ Los dos fallos que estos tests fijan estaban en producción y se reprodujeron:
 una carpeta con un apóstrofe en el nombre ejecutaba comandos arbitrarios, y el
 glob entrecomillado hacía que el borrado no borrara nada y saliera con éxito.
 """
+import contextlib
+import io
 import os
 import subprocess
 import tempfile
@@ -173,3 +175,43 @@ def test_du_sh_otros_escapa_la_ruta_y_de_verdad_lista_el_contenido():
         assert not os.path.exists(os.path.join(box, "pwned")), (
             "se ejecutó un comando arbitrario embebido en el nombre de la carpeta"
         )
+
+
+def test_print_report_escapa_el_rm_f_sugerido_para_cache():
+    """disk_analyzer.py:1354 imprimía `rm -f '{f['path']}'` en el reporte de
+    consola (sección "COMANDOS DE LIMPIEZA SUGERIDOS") con comillas simples
+    manuales sin escapar -- el mismo patrón que el bug original, solo que
+    aquí nadie lo ejecuta automáticamente: el CLI se lo ofrece a un humano
+    para copiar y pegar. El aviso de "revisa antes de ejecutar" no protege
+    de nada porque nadie audita el entrecomillado a ojo, así que cuenta como
+    el mismo defecto.
+    """
+    analyzer = DiskAnalyzer(".")
+    peligroso = "/tmp/x' ; touch pwned ; echo '/cache.db"
+
+    report = {
+        'summary': {
+            'total_size': 0, 'files_scanned': 0, 'large_files_count': 1,
+            'recoverable_space': 0,
+        },
+        'docker': None,
+        'recommendations': [],
+        'top_directories': [],
+        'top_file_types': [],
+        'large_files': [
+            {'path': peligroso, 'size': 1024, 'age_days': 5, 'is_cache': True},
+        ],
+        'cache_locations': [],
+    }
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        analyzer.print_report(report)
+    salida = buffer.getvalue()
+
+    lineas_rm = [l.strip() for l in salida.splitlines() if l.strip().startswith('rm -f')]
+    assert lineas_rm, "no se imprimió ninguna línea 'rm -f' (fixture desalineado)"
+
+    # Si el nombre volviera a interpolarse sin escapar, shlex.split trocearía
+    # el comando en piezas de más en vez de tratar la ruta como un solo token.
+    assert shlex.split(lineas_rm[0]) == ["rm", "-f", peligroso]

--- a/tests/test_core_engine.py
+++ b/tests/test_core_engine.py
@@ -45,9 +45,13 @@ class TestRecommendationLabels:
         self.core = DiskAnalyzerCore(".")
 
     def test_vscode_and_npm_recommendations_fire(self):
-        # Labels exactly as categorize_cache produces them.
+        # Labels exactly as categorize_cache produces them. Paths also match
+        # the real cache locations these rules scope to (Task 4 of the final
+        # review pass: logs/vscode/npm/papelera filter by path as well as
+        # `type`, not just `type` alone) -- an arbitrary '/fake/...' path
+        # wouldn't fire either rule any more.
         self.core.cache_locations = [
-            {"path": "/fake/Code/Cache", "size": 2 * GB, "type": "VS Code Cache"},
+            {"path": "/fake/Library/Application Support/Code/Cache", "size": 2 * GB, "type": "VS Code Cache"},
             {"path": "/fake/.npm", "size": 3 * GB, "type": "NPM Cache"},
         ]
         recs = self.core.generate_recommendations()

--- a/tests/test_efecto_recomendaciones.py
+++ b/tests/test_efecto_recomendaciones.py
@@ -145,3 +145,18 @@ def test_recomendaciones_inteligentes_con_efecto_correcto():
         assert recs[tipo]['efecto'] == efecto, (
             f"{tipo}: esperaba efecto={efecto!r}, encontré {recs[tipo].get('efecto')!r}"
         )
+
+
+def test_snapshots_time_machine_no_inventa_espacio():
+    """macOS no expone cuánto ocupa un snapshot local: `len(snapshot_dates) * GB`
+    era un número puesto a dedo (un GB fijo por snapshot), y ese campo
+    alimenta el total recuperable de la interfaz. No podemos reclamar un
+    espacio que no medimos: 'space' tiene que ser 0 hasta que exista una
+    medición real."""
+    recs = {r['type']: r for r in _recomendaciones_inteligentes()}
+    tipo = 'Snapshots Locales de Time Machine'
+    assert tipo in recs, f"No se disparó la detección: {tipo}"
+    assert recs[tipo]['space'] == 0, (
+        f"{tipo}: 'space' no puede ser una estimación inventada, "
+        f"encontré {recs[tipo]['space']!r}"
+    )

--- a/tests/test_efecto_recomendaciones.py
+++ b/tests/test_efecto_recomendaciones.py
@@ -27,14 +27,31 @@ from unittest.mock import patch
 sys.path.insert(0, '.')
 from disk_analyzer_core import DiskAnalyzerCore
 from disk_analyzer import DiskAnalyzer, MB, GB
+from tests.test_motor_unico import _estado_sintetico
 
 EFECTOS = {'borra', 'irreversible', 'solo_lista'}
 
 
 def _recomendaciones():
+    """Estado sintético (`_estado_sintetico`, compartido con
+    test_motor_unico.py), no un escaneo del disco real.
+
+    Antes esto llamaba a `core.find_cache_locations()`, que recorre
+    ~/Library/Caches, ~/.npm, etc. de verdad -- ~21 s por test, y en un
+    runner sin cachés reales devuelve una lista vacía, con lo que los tres
+    tests de este módulo pasaban sin comprobar nada (`for r in []` no
+    ejecuta ningún assert). El guard de no-vacuidad de abajo cierra ese
+    hueco: si algún día `_estado_sintetico()` deja de disparar ninguna
+    regla, estos tests fallan en vez de pasar en silencio.
+    """
+    locs, files, docker = _estado_sintetico()
     core = DiskAnalyzerCore('.')
-    core.find_cache_locations()
-    return core.generate_recommendations()
+    core.cache_locations = locs
+    core.large_files = files
+    core.docker_stats = docker
+    recs = core.generate_recommendations()
+    assert recs, "el estado sintético no disparó ninguna recomendación"
+    return recs
 
 
 def _recomendaciones_inteligentes():

--- a/tests/test_efecto_recomendaciones.py
+++ b/tests/test_efecto_recomendaciones.py
@@ -1,0 +1,51 @@
+"""Cada recomendación tiene que declarar qué hace su comando.
+
+Hoy se mezclan tres cosas distintas bajo el mismo botón:
+- borrados de ficheros, que podrían ir a la papelera;
+- invocaciones a herramientas (`docker system prune`, `brew cleanup`), que
+  borran por su cuenta y NO tienen papelera posible;
+- diagnósticos (`du -sh`, `find -ls`), que no borran nada.
+
+Sin este campo, la interfaz no puede prometer reversibilidad honestamente ni
+distinguir "liberó espacio" de "te enseñó una lista".
+"""
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer_core import DiskAnalyzerCore
+
+EFECTOS = {'borra', 'irreversible', 'solo_lista'}
+
+
+def _recomendaciones():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    return core.generate_recommendations()
+
+
+def test_toda_recomendacion_declara_su_efecto():
+    for r in _recomendaciones():
+        assert r.get('efecto') in EFECTOS, (
+            f"{r.get('type')} no declara efecto válido: {r.get('efecto')!r}"
+        )
+
+
+def test_los_comandos_que_solo_listan_estan_marcados():
+    """`du -sh` y `find -ls` no borran; acreditarles ahorro es mentir."""
+    for r in _recomendaciones():
+        cmd = r.get('command', '')
+        if cmd.startswith('du ') or ' -ls' in cmd:
+            assert r['efecto'] == 'solo_lista', (
+                f"{r['type']} ejecuta un diagnóstico pero no está marcado"
+            )
+
+
+def test_las_herramientas_externas_son_irreversibles():
+    """Nada de esto se puede mandar a la papelera."""
+    for r in _recomendaciones():
+        cmd = r.get('command', '')
+        if any(t in cmd for t in ('docker system prune', 'brew cleanup',
+                                  'npm cache clean', 'simctl delete')):
+            assert r['efecto'] == 'irreversible', (
+                f"{r['type']} invoca una herramienta externa: no hay papelera"
+            )

--- a/tests/test_efecto_recomendaciones.py
+++ b/tests/test_efecto_recomendaciones.py
@@ -8,11 +8,25 @@ Hoy se mezclan tres cosas distintas bajo el mismo botón:
 
 Sin este campo, la interfaz no puede prometer reversibilidad honestamente ni
 distinguir "liberó espacio" de "te enseñó una lista".
+
+Hay dos fuentes de recomendaciones que hay que cubrir por separado:
+- `disk_analyzer_core.DiskAnalyzerCore.generate_recommendations` (motor
+  compartido, usado por la web).
+- `disk_analyzer.DiskAnalyzer.detect_smart_recommendations` (patrones
+  avanzados de la CLI/app de bandeja: `disk_analyzer.py` es lo que invoca
+  `desktop/src-tauri/src/analisis.rs`, no el core). La copia de
+  `generate_recommendations` que también vive en `disk_analyzer.py` no se
+  cubre aquí a propósito: un task posterior la sustituye por una delegación
+  al core y heredará las etiquetas sola.
 """
+import subprocess
 import sys
+from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, '.')
 from disk_analyzer_core import DiskAnalyzerCore
+from disk_analyzer import DiskAnalyzer, MB, GB
 
 EFECTOS = {'borra', 'irreversible', 'solo_lista'}
 
@@ -21,6 +35,49 @@ def _recomendaciones():
     core = DiskAnalyzerCore('.')
     core.find_cache_locations()
     return core.generate_recommendations()
+
+
+def _recomendaciones_inteligentes():
+    """Construye un DiskAnalyzer con estado sintético que dispara las 6
+    detecciones de detect_smart_recommendations, sin tocar el disco real
+    (salvo la llamada a `tmutil`, que se mockea)."""
+    home = str(Path.home())
+    analyzer = DiskAnalyzer('.')
+
+    # 1. Entorno Conda obsoleto: env sin actividad reciente (>180 días)
+    conda_env = f'{home}/miniconda3/envs/entorno_de_prueba'
+    analyzer.directory_sizes[conda_env] = 500 * MB
+    analyzer.large_files.append({
+        'path': f'{conda_env}/lib/python3.11/algo.so',
+        'size': 500 * MB, 'age_days': 200,
+    })
+
+    # 2. node_modules huérfano: sin .git/HEAD ni package.json en el padre
+    node_modules = '/ruta_de_prueba_que_no_existe_xyz/proyecto/node_modules'
+    analyzer.directory_sizes[node_modules] = 300 * MB
+
+    # 3. Múltiples instalaciones de Python (Homebrew + Anaconda, ambas >100MB)
+    analyzer.directory_sizes['/opt/homebrew/lib/python3.11'] = 150 * MB
+    analyzer.directory_sizes['/opt/anaconda3/lib/python3.11'] = 150 * MB
+
+    # 4. Repo git con pack files grandes (>100MB)
+    analyzer.large_files.append({
+        'path': '/ruta_de_prueba_repo/.git/objects/pack/pack-abc123.pack',
+        'size': 150 * MB, 'age_days': 5,
+    })
+
+    # 5. Snapshots locales de Time Machine (mockeado, no toca el sistema real)
+    fake_tmutil = subprocess.CompletedProcess(
+        args=['tmutil', 'listlocalsnapshots', '/'], returncode=0,
+        stdout='com.apple.TimeMachine.2024-01-01-000000.local\n',
+    )
+
+    # 6. Xcode Archives antiguos (>1GB)
+    xcode_archives = f'{home}/Library/Developer/Xcode/Archives'
+    analyzer.directory_sizes[f'{xcode_archives}/2024-01-01/App.xcarchive'] = 2 * GB
+
+    with patch('disk_analyzer.subprocess.run', return_value=fake_tmutil):
+        return analyzer.detect_smart_recommendations()
 
 
 def test_toda_recomendacion_declara_su_efecto():
@@ -49,3 +106,42 @@ def test_las_herramientas_externas_son_irreversibles():
             assert r['efecto'] == 'irreversible', (
                 f"{r['type']} invoca una herramienta externa: no hay papelera"
             )
+
+
+def test_toda_recomendacion_inteligente_declara_su_efecto():
+    """detect_smart_recommendations es una fuente propia (CLI + app de
+    bandeja, via disk_analyzer.py) y tiene que declarar 'efecto' igual que
+    el motor compartido."""
+    recs = _recomendaciones_inteligentes()
+    tipos_esperados = {
+        'Entorno Conda Obsoleto', 'node_modules Huerfano',
+        'Multiples Instalaciones Python', 'Git Pack Files Grandes',
+        'Snapshots Locales de Time Machine', 'Xcode Archives Antiguos',
+    }
+    tipos_encontrados = {r['type'] for r in recs}
+    assert tipos_esperados <= tipos_encontrados, (
+        f"El estado sintético no disparó todas las detecciones esperadas: "
+        f"faltan {tipos_esperados - tipos_encontrados}"
+    )
+    for r in recs:
+        assert r.get('efecto') in EFECTOS, (
+            f"{r.get('type')} no declara efecto válido: {r.get('efecto')!r}"
+        )
+
+
+def test_recomendaciones_inteligentes_con_efecto_correcto():
+    """Cada detección inteligente clasificada según su comando real."""
+    esperado = {
+        'Entorno Conda Obsoleto': 'irreversible',       # conda env remove
+        'node_modules Huerfano': 'borra',                # comandos.borrar_rutas
+        'Multiples Instalaciones Python': 'solo_lista',  # comentario, no acción
+        'Git Pack Files Grandes': 'irreversible',        # git gc --aggressive
+        'Snapshots Locales de Time Machine': 'irreversible',  # tmutil
+        'Xcode Archives Antiguos': 'borra',              # comandos.borrar_contenido
+    }
+    recs = {r['type']: r for r in _recomendaciones_inteligentes()}
+    for tipo, efecto in esperado.items():
+        assert tipo in recs, f"No se disparó la detección: {tipo}"
+        assert recs[tipo]['efecto'] == efecto, (
+            f"{tipo}: esperaba efecto={efecto!r}, encontré {recs[tipo].get('efecto')!r}"
+        )

--- a/tests/test_engine_characterization.py
+++ b/tests/test_engine_characterization.py
@@ -198,9 +198,12 @@ class TestCacheClassification:
 class TestRecommendations:
     def test_recommendations_have_required_shape(self):
         core = DiskAnalyzerCore(".")
+        # Paths match the real cache locations the npm/vscode rules scope to
+        # (Task 4 of the final review pass) -- an arbitrary '/fake/...' path
+        # no longer fires either rule.
         core.cache_locations = [
-            {"path": "/fake/npm", "size": 3 * GB, "type": "NPM Cache"},
-            {"path": "/fake/code", "size": 2 * GB, "type": "VS Code Cache"},
+            {"path": "/fake/.npm", "size": 3 * GB, "type": "NPM Cache"},
+            {"path": "/fake/Library/Application Support/Code/Cache", "size": 2 * GB, "type": "VS Code Cache"},
         ]
         recs = core.generate_recommendations()
         assert recs, "expected recommendations for large known caches"
@@ -226,8 +229,8 @@ class TestRecommendations:
         # replaced with the wrong key -- verified by mutation (see report).
         core = DiskAnalyzerCore(".")
         core.cache_locations = [
-            {"path": "/fake/npm", "size": 9 * GB, "type": "NPM Cache"},
-            {"path": "/fake/code", "size": 3 * GB, "type": "VS Code Cache"},
+            {"path": "/fake/.npm", "size": 9 * GB, "type": "NPM Cache"},
+            {"path": "/fake/Library/Application Support/Code/Cache", "size": 3 * GB, "type": "VS Code Cache"},
         ]
         core.docker_stats = {"available": True, "reclaimable": 20 * GB}
         recs = core.generate_recommendations()

--- a/tests/test_motor_unico.py
+++ b/tests/test_motor_unico.py
@@ -1,0 +1,55 @@
+"""La CLI y la web tienen que ver las mismas recomendaciones.
+
+Hoy hay dos copias: `disk_analyzer_core.py:561` la usa la web y
+`disk_analyzer.py:888` la usan la CLI y la app de bandeja. La app de bandeja
+ejecuta `disk_analyzer.py`, así que la barra y la web pueden recomendar cosas
+distintas del mismo disco.
+
+Además, ninguna recomendación tiene identificador estable: `type` es una cadena
+de display en español y ya difiere entre copias ('Cache de Simuladores' contra
+'Cache de Simuladores iOS'). Sin `id` no se puede configurar nada.
+"""
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer import DiskAnalyzer
+from disk_analyzer_core import DiskAnalyzerCore
+
+
+def _preparar(obj, cache_locations, docker_stats=None):
+    obj.cache_locations = list(cache_locations)
+    obj.large_files = []
+    obj.docker_stats = docker_stats
+    return obj.generate_recommendations()
+
+
+def test_las_dos_interfaces_recomiendan_lo_mismo():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    locs, docker = core.cache_locations, core.docker_stats
+
+    del_core = _preparar(DiskAnalyzerCore('.'), locs, docker)
+    del_cli = _preparar(DiskAnalyzer('.'), locs, docker)
+
+    assert [r['id'] for r in del_core] == [r['id'] for r in del_cli]
+    assert [r['tier'] for r in del_core] == [r['tier'] for r in del_cli]
+    assert [r['command'] for r in del_core] == [r['command'] for r in del_cli]
+
+
+def test_los_ids_son_estables_y_no_son_texto_de_interfaz():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    for r in core.generate_recommendations():
+        ident = r.get('id', '')
+        assert ident, f"{r.get('type')} no tiene id"
+        assert ident.islower() and ' ' not in ident, (
+            f"{ident!r} parece texto de interfaz, no un identificador"
+        )
+        assert ident.isascii(), f"{ident!r} no es ascii: no sirve como clave"
+
+
+def test_los_ids_no_se_repiten():
+    core = DiskAnalyzerCore('.')
+    core.find_cache_locations()
+    ids = [r['id'] for r in core.generate_recommendations()]
+    assert len(ids) == len(set(ids)), f"ids duplicados: {ids}"

--- a/tests/test_motor_unico.py
+++ b/tests/test_motor_unico.py
@@ -8,38 +8,120 @@ distintas del mismo disco.
 Además, ninguna recomendación tiene identificador estable: `type` es una cadena
 de display en español y ya difiere entre copias ('Cache de Simuladores' contra
 'Cache de Simuladores iOS'). Sin `id` no se puede configurar nada.
+
+Los 12 IDs que produce `DiskAnalyzerCore.generate_recommendations()` hoy:
+logs, homebrew, vscode, npm, simuladores, descargas_antiguas, docker,
+cache_general, xcode_deriveddata, runtimes_simuladores, archivos_gigantes,
+maquinas_virtuales.
+
+Ronda de arreglo 1: `_preparar` original dejaba `large_files = []` y no
+poblaba `docker_stats`/`cache_locations` con nada realista, así que la
+"comparación completa" solo se verificó a mano en un script desechable que
+nunca quedó en el repositorio -- exactamente el hueco que este fixture
+cierra. El estado sintético de `_estado_sintetico()` dispara las 12 reglas
+a la vez, así que la comparación deja de ser vacua en una máquina/runner sin
+cachés reales.
 """
 import sys
+from unittest.mock import patch
 
 sys.path.insert(0, '.')
-from disk_analyzer import DiskAnalyzer, MB
+from disk_analyzer import DiskAnalyzer, MB, GB
 from disk_analyzer_core import DiskAnalyzerCore
 
+IDS_ESPERADOS = {
+    'logs', 'homebrew', 'vscode', 'npm', 'simuladores', 'descargas_antiguas',
+    'docker', 'cache_general', 'xcode_deriveddata', 'runtimes_simuladores',
+    'archivos_gigantes', 'maquinas_virtuales',
+}
 
-def _preparar(obj, cache_locations, docker_stats=None):
+
+def _estado_sintetico(home='/Users/prueba'):
+    """Estado sintético diseñado para disparar las 12 reglas de nivel a la
+    vez, sin depender de qué cachés existan de verdad en la máquina que
+    corre el test. Devuelve (cache_locations, large_files, docker_stats)."""
+    cache_locations = [
+        {'path': f'{home}/Library/Logs', 'size': 50 * MB, 'type': 'Logs del Sistema'},
+        {'path': f'{home}/Library/Application Support/Code/Cache', 'size': 50 * MB, 'type': 'VS Code Cache'},
+        {'path': f'{home}/.npm', 'size': 200 * MB, 'type': 'NPM Cache'},
+        {'path': f'{home}/.cache/huggingface', 'size': 500 * MB, 'type': 'Cache General'},
+        {'path': f'{home}/Library/Developer/Xcode/DerivedData', 'size': 500 * MB, 'type': 'Xcode Cache'},
+        # Deliberadamente también incluye Archives, clasificado igual (XCODE)
+        # que DerivedData -- ver test_xcode_deriveddata_no_incluye_archives.
+        {'path': f'{home}/Library/Developer/Xcode/Archives', 'size': 2 * GB, 'type': 'Xcode Cache'},
+    ]
+    large_files = [
+        {'path': f'{home}/Library/Caches/Homebrew/downloads/foo.tar.gz', 'size': 300 * MB,
+         'extension': '.gz', 'age_days': 5},
+        {'path': f'{home}/Library/Developer/CoreSimulator/Devices/ABCD/data/foo.bin', 'size': 400 * MB,
+         'extension': '.bin', 'age_days': 5},
+        {'path': f'{home}/Downloads/old_installer.dmg', 'size': 700 * MB,
+         'extension': '.dmg', 'age_days': 60},
+        {'path': f'{home}/Library/Developer/CoreSimulator/Profiles/Runtimes/'
+                  'iOSSimulatorRuntime.simruntime/big.dat',
+         'size': 2 * GB, 'extension': '.dat', 'age_days': 5},
+        {'path': '/tmp/huge_video_file.mov', 'size': int(1.5 * GB), 'extension': '.mov', 'age_days': 5},
+        {'path': f'{home}/VMs/ubuntu.vmdk', 'size': 3 * GB, 'extension': '.vmdk', 'age_days': 5},
+    ]
+    docker_stats = {'available': True, 'reclaimable': 500 * MB, 'total_size': 800 * MB}
+    return cache_locations, large_files, docker_stats
+
+
+def _preparar(obj, cache_locations, large_files=None, docker_stats=None):
     obj.cache_locations = list(cache_locations)
-    obj.large_files = []
+    obj.large_files = list(large_files) if large_files is not None else []
     obj.docker_stats = docker_stats
     return obj.generate_recommendations()
 
 
 def test_las_dos_interfaces_recomiendan_lo_mismo():
-    core = DiskAnalyzerCore('.')
-    core.find_cache_locations()
-    locs, docker = core.cache_locations, core.docker_stats
+    """Estado sintético que dispara las 12 reglas, no un escaneo del disco
+    real: así la aserción es la misma en cualquier máquina, tenga o no
+    cachés reales.
 
-    del_core = _preparar(DiskAnalyzerCore('.'), locs, docker)
-    del_cli = _preparar(DiskAnalyzer('.'), locs, docker)
+    detect_smart_recommendations() se neutraliza aquí a propósito: es una
+    fuente CLI-only, deliberadamente distinta entre interfaces (ver
+    docstring del módulo y tests/test_efecto_recomendaciones.py), así que
+    compararla junto a las 12 reglas compartidas mezclaría dos contratos
+    distintos. Que la delegación siga llamándola de verdad está cubierto
+    por test_la_delegacion_preserva_detect_smart_recommendations más abajo.
+    """
+    locs, files, docker = _estado_sintetico()
 
+    del_core = _preparar(DiskAnalyzerCore('.'), locs, files, docker)
+    with patch.object(DiskAnalyzer, 'detect_smart_recommendations', return_value=[]):
+        del_cli = _preparar(DiskAnalyzer('.'), locs, files, docker)
+
+    assert {r['id'] for r in del_core} == IDS_ESPERADOS, sorted(r['id'] for r in del_core)
     assert [r['id'] for r in del_core] == [r['id'] for r in del_cli]
     assert [r['tier'] for r in del_core] == [r['tier'] for r in del_cli]
     assert [r['command'] for r in del_core] == [r['command'] for r in del_cli]
 
 
+def test_la_delegacion_preserva_detect_smart_recommendations():
+    """Trampa 1 del task original: la delegación tiene que seguir llamando
+    a detect_smart_recommendations() y anexar su salida, no solo devolver
+    lo que presta el core. Si un refactor futuro "simplifica" la delegación
+    a un simple `return prestado.generate_recommendations()`, esta prueba
+    lo atrapa."""
+    cli = DiskAnalyzer('.')
+    cli.cache_locations = []
+    cli.large_files = []
+    cli.docker_stats = None
+    cli.directory_sizes['/ruta_de_prueba_que_no_existe_xyz/proyecto/node_modules'] = 300 * MB
+
+    recs = cli.generate_recommendations()
+    tipos = [r['type'] for r in recs]
+    assert 'node_modules Huerfano' in tipos, (
+        "detect_smart_recommendations() ya no se refleja en "
+        "generate_recommendations(): la delegación perdió la trampa 1"
+    )
+
+
 def test_los_ids_son_estables_y_no_son_texto_de_interfaz():
+    locs, files, docker = _estado_sintetico()
     core = DiskAnalyzerCore('.')
-    core.find_cache_locations()
-    for r in core.generate_recommendations():
+    for r in _preparar(core, locs, files, docker):
         ident = r.get('id', '')
         assert ident, f"{r.get('type')} no tiene id"
         assert ident.islower() and ' ' not in ident, (
@@ -49,10 +131,22 @@ def test_los_ids_son_estables_y_no_son_texto_de_interfaz():
 
 
 def test_los_ids_no_se_repiten():
+    locs, files, docker = _estado_sintetico()
     core = DiskAnalyzerCore('.')
-    core.find_cache_locations()
-    ids = [r['id'] for r in core.generate_recommendations()]
+    ids = [r['id'] for r in _preparar(core, locs, files, docker)]
     assert len(ids) == len(set(ids)), f"ids duplicados: {ids}"
+
+
+def test_las_doce_reglas_disparan_con_el_estado_sintetico():
+    """Fija la cobertura: si una regla deja de disparar (o una nueva no
+    declara su id), este test lo nota aunque la máquina que lo corre no
+    tenga ni un solo caché real -- a diferencia de los tests anteriores a
+    esta ronda, que dependían del disco real y podían pasar vacíamente."""
+    locs, files, docker = _estado_sintetico()
+    core = DiskAnalyzerCore('.')
+    recs = _preparar(core, locs, files, docker)
+    assert len(recs) == 12, f"se esperaban 12 recomendaciones, hubo {len(recs)}: {[r['id'] for r in recs]}"
+    assert {r['id'] for r in recs} == IDS_ESPERADOS
 
 
 def _un_download_viejo():
@@ -86,3 +180,56 @@ def test_la_cli_propaga_min_size_al_core_prestado():
     recs = {r['id']: r for r in cli.generate_recommendations()}
     assert 'descargas_antiguas' in recs
     assert '+77M' in recs['descargas_antiguas']['command'], recs['descargas_antiguas']['command']
+
+
+def test_min_size_cero_no_diverge_entre_cli_y_core():
+    """disk_analyzer.DiskAnalyzer siempre puso un piso de 1 MB
+    (`max(min_size_mb, 1)`); DiskAnalyzerCore no lo tenía, así que con
+    min_size_mb=0 la web generaba '-size +0M' (un filtro que no filtra
+    nada) mientras la CLI generaba '-size +1M'. Ambas clases tienen que
+    coincidir ahora que comparten la misma regla."""
+    core = DiskAnalyzerCore('.', min_size_mb=0)
+    core.cache_locations = []
+    core.docker_stats = None
+    core.large_files = _un_download_viejo()
+
+    cli = DiskAnalyzer('.', min_size_mb=0)
+    cli.cache_locations = []
+    cli.docker_stats = None
+    cli.large_files = _un_download_viejo()
+    with patch.object(DiskAnalyzer, 'detect_smart_recommendations', return_value=[]):
+        cli_recs = {r['id']: r for r in cli.generate_recommendations()}
+
+    core_recs = {r['id']: r for r in core.generate_recommendations()}
+
+    assert '+1M' in core_recs['descargas_antiguas']['command'], core_recs['descargas_antiguas']['command']
+    assert core_recs['descargas_antiguas']['command'] == cli_recs['descargas_antiguas']['command']
+
+
+def test_xcode_deriveddata_no_incluye_archives():
+    """CRÍTICO: cache_types.XCODE clasifica tanto DerivedData como Archives
+    (classify() solo mira si 'xcode' aparece en la ruta). Al mover esta
+    regla al core, filtrar por type=XCODE a secas metía los .xcarchive --
+    builds firmadas y dSYMs de versiones ya publicadas, irreversibles -- en
+    un comando 'rm -rf' descrito como "se regeneran al compilar". Este test
+    fija que el comando solo toca DerivedData."""
+    home = '/Users/prueba'
+    core = DiskAnalyzerCore('.')
+    core.cache_locations = [
+        {'path': f'{home}/Library/Developer/Xcode/DerivedData', 'size': 500 * MB, 'type': 'Xcode Cache'},
+        {'path': f'{home}/Library/Developer/Xcode/Archives', 'size': 5 * GB, 'type': 'Xcode Cache'},
+    ]
+    core.large_files = []
+    core.docker_stats = None
+
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'xcode_deriveddata' in recs
+    comando = recs['xcode_deriveddata']['command']
+    assert 'DerivedData' in comando
+    assert 'Archives' not in comando, (
+        f"el comando de xcode_deriveddata no debe tocar Archives: {comando!r}"
+    )
+    # El espacio reportado tampoco debe incluir los Archives (5 GB de la
+    # fixture): si el filtro se ampliara otra vez, este assert también lo
+    # atraparía aunque alguien reescribiera el comando a mano.
+    assert recs['xcode_deriveddata']['space'] == 500 * MB

--- a/tests/test_motor_unico.py
+++ b/tests/test_motor_unico.py
@@ -12,7 +12,7 @@ de display en español y ya difiere entre copias ('Cache de Simuladores' contra
 import sys
 
 sys.path.insert(0, '.')
-from disk_analyzer import DiskAnalyzer
+from disk_analyzer import DiskAnalyzer, MB
 from disk_analyzer_core import DiskAnalyzerCore
 
 
@@ -53,3 +53,36 @@ def test_los_ids_no_se_repiten():
     core.find_cache_locations()
     ids = [r['id'] for r in core.generate_recommendations()]
     assert len(ids) == len(set(ids)), f"ids duplicados: {ids}"
+
+
+def _un_download_viejo():
+    return [{'path': '/Users/x/Downloads/old.zip', 'size': 5 * MB,
+              'age_days': 45, 'extension': '.zip'}]
+
+
+def test_descargas_antiguas_respeta_min_size_en_el_core():
+    """La regla del core tiene que reflejar self.min_size en el comando, no
+    un umbral fijo -- si no, 'Descargas Antiguas' lista hasta los ficheros
+    minúsculos, algo mucho menos útil que lo que mostraba la CLI antes de
+    la fusión."""
+    core = DiskAnalyzerCore('.', min_size_mb=42)
+    core.cache_locations = []
+    core.docker_stats = None
+    core.large_files = _un_download_viejo()
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'descargas_antiguas' in recs
+    assert '+42M' in recs['descargas_antiguas']['command'], recs['descargas_antiguas']['command']
+
+
+def test_la_cli_propaga_min_size_al_core_prestado():
+    """Regresión: la delegación de disk_analyzer.py olvidaba pasar
+    min_size al DiskAnalyzerCore prestado, así que 'Descargas Antiguas'
+    dejaba de filtrar por tamaño para la CLI (y para la web, que comparte
+    la misma regla) sin que ningún test lo anclara."""
+    cli = DiskAnalyzer('.', min_size_mb=77)
+    cli.cache_locations = []
+    cli.docker_stats = None
+    cli.large_files = _un_download_viejo()
+    recs = {r['id']: r for r in cli.generate_recommendations()}
+    assert 'descargas_antiguas' in recs
+    assert '+77M' in recs['descargas_antiguas']['command'], recs['descargas_antiguas']['command']

--- a/tests/test_motor_unico.py
+++ b/tests/test_motor_unico.py
@@ -22,6 +22,7 @@ cierra. El estado sintético de `_estado_sintetico()` dispara las 12 reglas
 a la vez, así que la comparación deja de ser vacua en una máquina/runner sin
 cachés reales.
 """
+import os
 import sys
 from unittest.mock import patch
 
@@ -212,8 +213,15 @@ def test_xcode_deriveddata_no_incluye_archives():
     regla al core, filtrar por type=XCODE a secas metía los .xcarchive --
     builds firmadas y dSYMs de versiones ya publicadas, irreversibles -- en
     un comando 'rm -rf' descrito como "se regeneran al compilar". Este test
-    fija que el comando solo toca DerivedData."""
-    home = '/Users/prueba'
+    fija que el comando solo toca DerivedData.
+
+    Usa el $HOME real (no '/Users/prueba' como el resto del fixture): desde
+    que comandos.py instala la verja de protection.puede_borrarse (Task 7),
+    esta genera comandos reales para rutas dentro del HOME real -- un HOME
+    sintético cae bajo '/Users' (RUTAS_DE_DATOS_DE_USUARIO) y el comando
+    saldría vacío, lo que volvería vacuas las dos aserciones de contenido de
+    abajo."""
+    home = os.path.expanduser('~')
     core = DiskAnalyzerCore('.')
     core.cache_locations = [
         {'path': f'{home}/Library/Developer/Xcode/DerivedData', 'size': 500 * MB, 'type': 'Xcode Cache'},

--- a/tests/test_motor_unico.py
+++ b/tests/test_motor_unico.py
@@ -37,10 +37,22 @@ IDS_ESPERADOS = {
 }
 
 
-def _estado_sintetico(home='/Users/prueba'):
+def _estado_sintetico(home=None):
     """Estado sintético diseñado para disparar las 12 reglas de nivel a la
     vez, sin depender de qué cachés existan de verdad en la máquina que
-    corre el test. Devuelve (cache_locations, large_files, docker_stats)."""
+    corre el test. Devuelve (cache_locations, large_files, docker_stats).
+
+    `home` por defecto es el $HOME real de quien corre el test, no un
+    '/Users/prueba' sintético: desde que generate_recommendations() descarta
+    toda recomendación con 'command' vacío (Task 7, ronda de arreglo 1), un
+    home sintético cae bajo '/Users' (RUTAS_DE_DATOS_DE_USUARIO), su comando
+    sale vacío por la verja de protection.puede_borrarse, y la recomendación
+    entera desaparece -- exactamente lo que este fixture necesita evitar
+    para poder seguir dependiendo de las 12 reglas presentes a la vez. Sigue
+    aceptando un `home` explícito para quien quiera aislarse del $HOME real
+    a propósito."""
+    if home is None:
+        home = os.path.expanduser('~')
     cache_locations = [
         {'path': f'{home}/Library/Logs', 'size': 50 * MB, 'type': 'Logs del Sistema'},
         {'path': f'{home}/Library/Application Support/Code/Cache', 'size': 50 * MB, 'type': 'VS Code Cache'},

--- a/tests/test_protection.py
+++ b/tests/test_protection.py
@@ -74,3 +74,39 @@ class TestFreeFunctionBehaviors:
 
     def test_normal_user_file_is_not_protected(self):
         assert is_protected_path(str(Path.home() / "Downloads" / "movie.mp4")) is False
+
+
+class TestCaseInsensitivity:
+    """APFS no distingue mayúsculas de minúsculas por defecto: '/bin' y
+    '/BIN' son el mismo directorio. Verificado que, antes de este fix,
+    `/BIN` no lo capturaba `PROTECTED_ROOT_DIRS` (comparación case-sensitive
+    contra {'/bin', '/sbin'}), y como ni '/bin' ni '/sbin' están en
+    RUTAS_DE_DATOS_DE_USUARIO, `puede_borrarse('/BIN')` caía en su
+    `return True` final -- en un filesystem que no distingue caja, eso es
+    literalmente /bin.
+    """
+
+    @pytest.mark.parametrize("path", ["/BIN", "/Bin", "/bIn/ls", "/SBIN"])
+    def test_root_dirs_protected_regardless_of_case(self, path):
+        assert is_protected_path(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "/system/library/x",
+        "/SYSTEM/LIBRARY/X",
+        "/System/library",   # el directorio en sí, sin barra final, caja mixta
+        "/SYSTEM/LIBRARY",
+    ])
+    def test_system_prefixes_protected_regardless_of_case(self, path):
+        assert is_protected_path(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "/Applications/Foo.APP/Contents/MacOS/Foo",
+        "/Applications/Foo.app/CONTENTS/MacOS/Foo",
+        "/APPLICATIONS/FOO.APP/CONTENTS/MACOS/FOO",
+    ])
+    def test_app_contents_marker_protected_regardless_of_case(self, path):
+        assert is_protected_path(path) is True
+
+    @pytest.mark.parametrize("filename", ["SLEEPIMAGE", "SwapFile"])
+    def test_protected_filenames_protected_regardless_of_case(self, filename):
+        assert is_protected_path(str(Path.home() / "somewhere" / filename)) is True

--- a/tests/test_puede_borrarse.py
+++ b/tests/test_puede_borrarse.py
@@ -63,6 +63,42 @@ def test_las_caches_conocidas_si_se_borran(ruta):
     assert puede_borrarse(ruta), f"{ruta} debería poder limpiarse"
 
 
+# -- Segundo eje de la verja: por NOMBRE, no por ubicación (Task 7, ronda de
+# arreglo 1). detect_smart_recommendations() encuentra node_modules
+# huérfanos en cualquier proyecto del usuario -- rutas arbitrarias, no una
+# ubicación fija que se pueda añadir a _coincide_con_permitidas. Decisión de
+# producto explícita: node_modules se regenera con `npm install`, así que el
+# nombre solo basta, siempre que is_protected_path ya lo haya dejado pasar. --
+
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "Documents/repos/x/node_modules"),
+    os.path.join(CASA, "Developer/algun-proyecto/node_modules"),
+    "/Volumes/Backup Time Machine/proyecto/node_modules",
+])
+def test_node_modules_se_puede_borrar_por_nombre_aunque_este_en_datos_de_usuario(ruta):
+    assert puede_borrarse(ruta), (
+        f"{ruta} debería poder limpiarse: se llama 'node_modules'"
+    )
+
+
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "Documents/repos/x"),
+    os.path.join(CASA, "Documents"),
+])
+def test_el_padre_de_node_modules_no_se_puede_borrar(ruta):
+    """El eje por nombre es estrecho a propósito: solo el directorio que se
+    llama exactamente 'node_modules', nunca su padre ni el resto de
+    ~/Documents."""
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable"
+
+
+def test_node_modules_sigue_protegido_si_esta_bajo_una_ruta_de_sistema():
+    """El eje por nombre no pasa por encima de is_protected_path: la regla
+    del brief para instalar la verja era 'siempre que siga pasando
+    is_protected_path', no un comodín absoluto."""
+    assert not puede_borrarse("/System/Library/node_modules")
+
+
 def test_una_ruta_relativa_o_vacia_nunca_se_borra(monkeypatch):
     # cwd deliberadamente fuera de cualquier prefijo prohibido: /cores no
     # aparece en RUTAS_DE_DATOS_DE_USUARIO ni en is_protected_path. Si el

--- a/tests/test_puede_borrarse.py
+++ b/tests/test_puede_borrarse.py
@@ -63,6 +63,44 @@ def test_las_caches_conocidas_si_se_borran(ruta):
     assert puede_borrarse(ruta), f"{ruta} debería poder limpiarse"
 
 
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "Downloads"),
+    os.path.join(CASA, "Library/Developer/CoreSimulator/Devices"),
+    os.path.join(CASA, "Library/Developer/CoreSimulator/Devices/ABCD-1234/data"),
+])
+def test_las_rutas_que_el_endpoint_web_borraba_igual_siguen_prohibidas(ruta):
+    """Revisión final (ola de saneamiento), hallazgo 2: sobre el home real,
+    de 10 objetivos que el endpoint de limpieza web mandaba a
+    _perform_cleanup_deletes, dos eran cosas que esta verja prohíbe
+    explícitamente -- ~/Downloads y
+    ~/Library/Developer/CoreSimulator/Devices -- y se borraban igual
+    porque ese endpoint solo filtraba con is_protected_path (lista negra
+    del sistema operativo), no con puede_borrarse. Esto fija el lado de la
+    verja: si alguna vez vuelve a fallar, no es porque puede_borrarse haya
+    dejado de rechazarlas."""
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable"
+
+
+def test_containers_docker_data_ya_no_esta_en_la_whitelist():
+    """~/Library/Containers/com.docker.docker/Data estuvo en
+    _coincide_con_permitidas, pero ninguna regla de generate_recommendations
+    ni de detect_smart_recommendations genera un comando de borrado contra
+    esa ruta -- la limpieza de Docker siempre pasa por `docker system
+    prune`/`docker volume`/`docker image`. Bajo esa ruta viven los
+    volúmenes CON NOMBRE de Docker (bases de datos y otros datos
+    persistentes del usuario), así que estar en la whitelist era un
+    borrado silencioso de datos de usuario esperando un disparador: el
+    endpoint web de limpieza (`_perform_cleanup_deletes`) podía llegar a
+    ella a través de find_cache_locations() + una categoría "Docker"
+    elegida a mano. Se quitó de la whitelist; este test fija que se queda
+    fuera."""
+    ruta = os.path.join(CASA, "Library/Containers/com.docker.docker/Data")
+    assert not _coincide_con_permitidas(ruta), (
+        f"{ruta} sigue en la whitelist de cachés conocidas"
+    )
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable"
+
+
 # -- Segundo eje de la verja: por NOMBRE, no por ubicación (Task 7, ronda de
 # arreglo 1). detect_smart_recommendations() encuentra node_modules
 # huérfanos en cualquier proyecto del usuario -- rutas arbitrarias, no una

--- a/tests/test_puede_borrarse.py
+++ b/tests/test_puede_borrarse.py
@@ -1,0 +1,143 @@
+"""Qué se puede borrar de verdad.
+
+`is_protected_path` es una lista negra del sistema operativo: sirve para "no
+toques macOS", no para "esto es seguro de borrar". Verificado: devuelve False
+(borrable) para ~/Documents, ~/Desktop, iCloud Drive, /Volumes/... y el propio
+$HOME. Con "añadir carpetas propias" eso apuntaría a los datos del usuario.
+"""
+import os
+
+import pytest
+
+from analyzer.protection import puede_borrarse, _coincide_con_permitidas
+
+CASA = os.path.expanduser("~")
+
+
+@pytest.fixture
+def enlace_de_cache_a_documents():
+    """Crea un enlace simbólico real dentro de un directorio permitido
+    (~/Library/Caches) que apunta a uno prohibido (~/Documents), y lo borra
+    al terminar. No toca el contenido de ~/Documents, solo enlaza a él.
+
+    Reproduce el escape real: `borrar_contenido` ejecuta `rm -rf <ruta>/*`, y
+    ese glob SÍ atraviesa un enlace simbólico hacia lo que sea que apunte.
+    """
+    caches = os.path.join(CASA, "Library/Caches")
+    documents = os.path.join(CASA, "Documents")
+    if not os.path.isdir(caches) or not os.path.isdir(documents):
+        pytest.skip("requiere ~/Library/Caches y ~/Documents reales")
+    enlace = os.path.join(caches, f"_test_puede_borrarse_atajo_{os.getpid()}")
+    if os.path.islink(enlace) or os.path.exists(enlace):
+        os.unlink(enlace)
+    os.symlink(documents, enlace)
+    try:
+        yield enlace
+    finally:
+        os.unlink(enlace)
+
+
+@pytest.mark.parametrize("ruta", [
+    CASA,
+    os.path.join(CASA, "Documents"),
+    os.path.join(CASA, "Desktop"),
+    os.path.join(CASA, "Pictures"),
+    os.path.join(CASA, "Library/Mobile Documents"),          # iCloud Drive
+    os.path.join(CASA, "Library/Mobile Documents/algo/mio"),  # y su contenido
+    "/Volumes/Backup Time Machine",
+    "/Volumes/Backup Time Machine/2026",
+    "/System/Library",     # el directorio en sí, no solo su contenido
+    "/System",
+    "/",
+])
+def test_los_datos_del_usuario_y_el_sistema_no_se_borran(ruta):
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable"
+
+
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "Library/Caches/com.apple.Safari"),
+    os.path.join(CASA, ".npm/_cacache"),
+    os.path.join(CASA, "Library/Logs/algo.log"),
+])
+def test_las_caches_conocidas_si_se_borran(ruta):
+    assert puede_borrarse(ruta), f"{ruta} debería poder limpiarse"
+
+
+def test_una_ruta_relativa_o_vacia_nunca_se_borra(monkeypatch):
+    # cwd deliberadamente fuera de cualquier prefijo prohibido: /cores no
+    # aparece en RUTAS_DE_DATOS_DE_USUARIO ni en is_protected_path. Si el
+    # rechazo de rutas relativas dependiera (por accidente) de que
+    # abspath() aterrizara bajo una zona ya protegida -- como pasaba antes,
+    # cuando ese chequeo era código muerto -- este cwd lo dejaría al
+    # descubierto: con el bug, `relativa/sin/raiz` se convertiría en
+    # `/cores/relativa/sin/raiz`, que no está prohibida por ningún otro
+    # motivo, y el test fallaría.
+    monkeypatch.chdir("/cores")
+    assert not puede_borrarse("")
+    assert not puede_borrarse("relativa/sin/raiz")
+
+
+def test_no_se_puede_escapar_con_puntos():
+    """`~/Library/Caches/../../Documents` es ~/Documents disfrazado."""
+    assert not puede_borrarse(os.path.join(CASA, "Library/Caches/../../Documents"))
+
+
+def test_los_temporales_del_sistema_los_gestiona_macos():
+    """`/private/var/folders` está protegido a propósito.
+
+    Aparece entre las cachés que el escáner encuentra (4,14 GB medidos), pero
+    macOS gestiona ese directorio por su cuenta y borrarlo entero es
+    arriesgado. Este test existe para que quede claro que la exclusión es
+    deliberada y no un olvido.
+    """
+    assert not puede_borrarse('/private/var/folders')
+    assert not puede_borrarse('/private/var/folders/x_/algo/T/tmpabc')
+
+
+@pytest.mark.parametrize("ruta", [
+    "/volumes/Backup Time Machine",            # /Volumes en minúsculas
+    "/VOLUMES/BACKUP TIME MACHINE",            # todo en mayúsculas
+    os.path.join(CASA.upper(), "DOCUMENTS"),   # ~/Documents con otra caja
+])
+def test_una_ruta_prohibida_sigue_prohibida_con_otra_caja(ruta):
+    """APFS no distingue mayúsculas de minúsculas por defecto: cambiar la
+    caja de una ruta prohibida no puede ser una forma de colarla."""
+    assert not puede_borrarse(ruta), f"{ruta} salió como borrable (bypass por caja)"
+
+
+@pytest.mark.parametrize("ruta", [
+    os.path.join(CASA, "LIBRARY/CACHES/com.apple.Safari"),
+    os.path.join(CASA.upper(), "LIBRARY/CACHES/COM.APPLE.SAFARI"),
+    os.path.join(CASA, ".NPM/_cacache"),
+])
+def test_una_cache_legitima_sigue_limpiable_con_otra_caja(ruta):
+    """Lo simétrico del test anterior: normalizar la caja no puede volverse
+    tan estricto que una caché real deje de reconocerse.
+
+    La afirmación es sobre `_coincide_con_permitidas`, no sobre
+    `puede_borrarse` directamente: `puede_borrarse` tiene un `return True`
+    por defecto al final, así que un `True` suyo no prueba que la ruta se
+    haya reconocido como caché -- podría estar colándose por la puerta de
+    atrás (que es justo el bug que este mismo test debía cazar y, en una de
+    sus variantes, no cazaba). `_coincide_con_permitidas` no tiene ese
+    "por defecto": si devuelve True es porque hubo coincidencia real.
+    """
+    assert _coincide_con_permitidas(ruta), (
+        f"{ruta} no se reconoció como una caché conocida pese a la caja distinta"
+    )
+    # Y de paso, el comportamiento público de extremo a extremo también debe
+    # sostenerse (esto sí puede pasar "por casualidad" en alguna variante,
+    # pero la aserción de arriba ya cierra ese hueco).
+    assert puede_borrarse(ruta), f"{ruta} debería poder limpiarse pese a la caja distinta"
+
+
+def test_un_enlace_simbolico_no_permite_escapar_de_una_cache(enlace_de_cache_a_documents):
+    """Un enlace real dentro de ~/Library/Caches (permitida) que apunta a
+    ~/Documents (prohibida) no debe ser borrable.
+
+    `borrar_contenido` ejecuta `rm -rf <ruta>/*`, y ese glob atraviesa el
+    enlace: `abspath`/`normpath` no lo resuelven, hace falta `realpath`.
+    """
+    assert not puede_borrarse(enlace_de_cache_a_documents), (
+        f"{enlace_de_cache_a_documents} salió como borrable (escapa a ~/Documents)"
+    )

--- a/tests/test_reglas_nuevas.py
+++ b/tests/test_reglas_nuevas.py
@@ -9,6 +9,7 @@ propios tests llamaba.
 """
 import os
 import sys
+from unittest.mock import patch
 
 sys.path.insert(0, '.')
 from disk_analyzer_core import DiskAnalyzerCore
@@ -166,6 +167,75 @@ def test_una_regla_totalmente_bloqueada_por_la_verja_no_aparece():
         "la regla 'logs' apareció con una ruta que la verja debería haber "
         "descartado por completo -- si esto es intencional, contradice la "
         "garantía de que ninguna recomendación sale con 'command' vacío"
+    )
+
+
+# -- Revisión final, hallazgo 4: las cuatro reglas de nivel 1 (logs, vscode,
+# npm, papelera) filtraban solo por `type`, incumpliendo la norma que este
+# mismo módulo ya fija para caches_de_apps (arriba). Misma causa raíz que el
+# hallazgo 1: si cache_types.classify() etiqueta ~/Library/Caches como
+# VSCODE -- lo que pasaba, antes de arreglar classify(), con cualquier
+# nombre de usuario que contuviera la subcadena 'code' -- la regla vscode
+# (nivel 1, sin revisión) se llevaba esos GB en vez de caches_de_apps (nivel
+# 2, la que de verdad le corresponde). Estas pruebas no dependen de que
+# classify() tenga el bug: construyen directamente una cache_location con el
+# `type` "equivocado" para comprobar que cada regla se defiende también por
+# ruta, no solo confiando en el `type` que le pasan.
+#
+# `puede_borrarse` se parchea a "todo pasa" en las cuatro: una ruta sintética
+# como '/Users/nicode/...' no cae bajo el $HOME real de quien corre el test,
+# así que la verja la rechazaría por esa razón AJENA (cualquier ruta bajo
+# '/Users' que no sea una de las cachés conocidas del HOME real -- ver
+# protection.py) y el assert "no aparece" pasaría igual sin que el fix de
+# ESTE hallazgo tuviera nada que ver. Parcheando la verja, lo único que
+# puede hacer desaparecer la recomendación es el acotado por ruta de la
+# regla misma -- que es justo lo que se quiere probar aquí. --
+
+def test_home_con_code_no_termina_en_la_regla_vscode():
+    ruta = '/Users/nicode/Library/Caches'
+    core = _core_con([
+        {'type': cache_types.VSCODE, 'path': ruta, 'size': 21 * GB},
+    ])
+    with patch('analyzer.comandos.puede_borrarse', return_value=True):
+        recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'vscode' not in recs, (
+        f"~/Library/Caches se coló en la regla vscode: {recs.get('vscode')}"
+    )
+
+
+def test_home_con_log_no_termina_en_la_regla_logs():
+    ruta = '/Users/logan/Downloads'
+    core = _core_con([
+        {'type': cache_types.LOGS, 'path': ruta, 'size': 5 * GB},
+    ])
+    with patch('analyzer.comandos.puede_borrarse', return_value=True):
+        recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'logs' not in recs, (
+        f"~/Downloads se coló en la regla logs: {recs.get('logs')}"
+    )
+
+
+def test_home_con_node_no_termina_en_la_regla_npm():
+    ruta = '/Users/anode/Downloads'
+    core = _core_con([
+        {'type': cache_types.NPM, 'path': ruta, 'size': 5 * GB},
+    ])
+    with patch('analyzer.comandos.puede_borrarse', return_value=True):
+        recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'npm' not in recs, (
+        f"~/Downloads se coló en la regla npm: {recs.get('npm')}"
+    )
+
+
+def test_una_ruta_ajena_no_termina_en_la_regla_papelera():
+    ruta = '/Users/x/Documents/algo_que_no_es_la_papelera'
+    core = _core_con([
+        {'type': cache_types.TRASH, 'path': ruta, 'size': 5 * GB},
+    ])
+    with patch('analyzer.comandos.puede_borrarse', return_value=True):
+        recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'papelera' not in recs, (
+        f"una ruta que no es ~/.Trash se coló en la regla papelera: {recs.get('papelera')}"
     )
 
 

--- a/tests/test_reglas_nuevas.py
+++ b/tests/test_reglas_nuevas.py
@@ -1,0 +1,123 @@
+"""Las reglas que dejaban fuera el 80% de lo encontrado.
+
+Contexto medido en la máquina de referencia: 101,85 GB en cachés, pero solo
+17,6 GB recomendados y solo 4,01 GB de nivel 1. Docker (39,6 GB),
+~/Library/Caches (21,4 GB) y la papelera se quedaban fuera. Este módulo fija
+las reglas que cierran ese hueco, más la verja de borrado
+(analyzer.protection.puede_borrarse) que hasta ahora nadie fuera de sus
+propios tests llamaba.
+"""
+import os
+import sys
+
+sys.path.insert(0, '.')
+from disk_analyzer_core import DiskAnalyzerCore
+from analyzer import cache_types
+from analyzer import comandos
+from analyzer.protection import puede_borrarse
+
+GB = 1024 ** 3
+MB = 1024 ** 2
+
+
+def _core_con(locs, docker=None):
+    core = DiskAnalyzerCore('.')
+    core.cache_locations = locs
+    core.large_files = []
+    core.docker_stats = docker
+    return core
+
+
+def test_las_caches_de_library_se_recomiendan():
+    """21,4 GB reales en la máquina de desarrollo, sin ninguna regla."""
+    ruta = os.path.expanduser('~/Library/Caches')
+    core = _core_con([{'type': cache_types.GENERAL, 'path': ruta,
+                       'size': 21 * GB}])
+    ids = {r['id'] for r in core.generate_recommendations()}
+    assert 'caches_de_apps' in ids
+
+
+def test_la_papelera_se_recomienda():
+    ruta = os.path.expanduser('~/.Trash')
+    core = _core_con([{'type': cache_types.TRASH, 'path': ruta,
+                       'size': 3 * GB}])
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'papelera' in recs
+    assert recs['papelera']['tier'] == 1, "vaciar la papelera es seguro"
+
+
+def test_docker_aparece_solo_con_docker_stats():
+    """No debe exigir un escaneo del disco completo: `docker system df` basta."""
+    core = _core_con([], docker={'available': True, 'reclaimable': 39 * GB})
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'docker' in recs
+    assert recs['docker']['efecto'] == 'irreversible'
+
+
+def test_las_caches_de_apps_no_incluyen_datos_de_usuario():
+    """La regla no puede arrastrar nada que no sea caché."""
+    core = _core_con([{'type': cache_types.GENERAL,
+                       'path': os.path.expanduser('~/Library/Caches'),
+                       'size': 21 * GB}])
+    for r in core.generate_recommendations():
+        if r['id'] == 'caches_de_apps':
+            assert puede_borrarse(os.path.expanduser('~/Library/Caches'))
+
+
+# -- Norma innegociable del task: ninguna regla filtra solo por `type`, tiene
+# que acotar también por ruta. cache_types.GENERAL agrupa ~/Library/Caches
+# (lo que la regla SÍ debe tocar) junto con
+# ~/Library/Developer/CoreSimulator/Devices (simuladores instalados, no una
+# caché) y /private/var/folders (lo gestiona macOS). Mismo defecto que casi
+# se publica una vez con cache_types.XCODE mezclando DerivedData y Archives:
+# el comando de 'caches_de_apps' no puede mencionar ninguna de las dos, aunque
+# ambas estén presentes en cache_locations junto a la caché real. --
+
+def test_caches_de_apps_no_arrastra_coresimulator_ni_var_folders():
+    coresim = os.path.expanduser('~/Library/Developer/CoreSimulator/Devices')
+    varfolders = '/private/var/folders'
+    caches = os.path.expanduser('~/Library/Caches')
+    core = _core_con([
+        {'type': cache_types.GENERAL, 'path': caches, 'size': 21 * GB},
+        {'type': cache_types.GENERAL, 'path': coresim, 'size': 15 * GB},
+        {'type': cache_types.GENERAL, 'path': varfolders, 'size': 4 * GB},
+    ])
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'caches_de_apps' in recs
+    cmd = recs['caches_de_apps']['command']
+    assert coresim not in cmd, "arrastró simuladores instalados a un 'borra'"
+    assert varfolders not in cmd, "arrastró /private/var/folders, lo gestiona macOS"
+    assert caches in cmd
+
+
+# -- Requisito añadido: instalar la verja de borrado en comandos.py. --
+
+def test_una_ruta_prohibida_se_descarta_aunque_se_pase():
+    """~/Documents nunca puede acabar en un comando de borrado, ni aunque
+    una regla (con un bug, o de forma maliciosa) intente pasarla."""
+    documents = os.path.expanduser('~/Documents')
+    assert comandos.borrar_contenido([documents]) == ""
+    assert comandos.borrar_rutas([documents]) == ""
+
+
+def test_las_caches_conocidas_siguen_generando_comando():
+    """La verja no puede convertirse en una lista negra que también bloquee
+    lo legítimo: las cachés reales de la whitelist siguen pasando."""
+    caches = os.path.expanduser('~/Library/Caches')
+    assert caches in comandos.borrar_contenido([caches])
+
+    trash = os.path.expanduser('~/.Trash')
+    assert trash in comandos.borrar_contenido([trash])
+
+
+def test_xcode_archives_sigue_generando_comando_con_la_verja_instalada():
+    """detect_smart_recommendations() (disk_analyzer.py, id
+    'xcode_archives_antiguos') ya construía su comando con
+    comandos.borrar_contenido sobre ~/Library/Developer/Xcode/Archives antes
+    de este task. Sin añadir esa ruta a la whitelist de protection.py, la
+    verja recién instalada la habría descartado en silencio -- ninguno de
+    los tests existentes (test_efecto_recomendaciones.py) lo habría cazado
+    porque solo comprueban 'efecto', no el contenido del comando."""
+    archives = os.path.expanduser('~/Library/Developer/Xcode/Archives')
+    assert puede_borrarse(archives)
+    assert archives in comandos.borrar_contenido([archives])

--- a/tests/test_reglas_nuevas.py
+++ b/tests/test_reglas_nuevas.py
@@ -54,15 +54,13 @@ def test_docker_aparece_solo_con_docker_stats():
     assert recs['docker']['efecto'] == 'irreversible'
 
 
-def test_las_caches_de_apps_no_incluyen_datos_de_usuario():
-    """La regla no puede arrastrar nada que no sea caché."""
-    core = _core_con([{'type': cache_types.GENERAL,
-                       'path': os.path.expanduser('~/Library/Caches'),
-                       'size': 21 * GB}])
-    for r in core.generate_recommendations():
-        if r['id'] == 'caches_de_apps':
-            assert puede_borrarse(os.path.expanduser('~/Library/Caches'))
-
+# -- Ronda de arreglo 1: el test que pedía el brief para "la regla no puede
+# arrastrar nada que no sea caché" era vacuo -- su único assert vive dentro de
+# un `if r['id'] == 'caches_de_apps':` sin `else` que falle si la regla no
+# dispara, así que pasaba igual sin la regla presente. Se borra en vez de
+# arreglarse: test_caches_de_apps_no_arrastra_coresimulator_ni_var_folders de
+# abajo cubre la misma intención con aserciones estrictas (falla si la regla
+# no aparece, falla si arrastra las rutas que no debe). --
 
 # -- Norma innegociable del task: ninguna regla filtra solo por `type`, tiene
 # que acotar también por ruta. cache_types.GENERAL agrupa ~/Library/Caches
@@ -121,3 +119,66 @@ def test_xcode_archives_sigue_generando_comando_con_la_verja_instalada():
     archives = os.path.expanduser('~/Library/Developer/Xcode/Archives')
     assert puede_borrarse(archives)
     assert archives in comandos.borrar_contenido([archives])
+
+
+# -- Ronda de arreglo 1, punto 1: decisión de producto explícita -- node_modules
+# se borra por NOMBRE (segundo eje de la verja en protection.py), no porque
+# ~/Documents/repos/... esté en ninguna whitelist de rutas. La alternativa
+# (dejar el comando vacío) es peor que no tener la regla: una recomendación
+# que promete decenas de GB y cuyo botón no hace nada. --
+
+def test_node_modules_huerfano_genera_comando_real_con_la_verja_instalada():
+    """detect_smart_recommendations() (disk_analyzer.py, id
+    'node_modules_huerfano') construye su comando con comandos.borrar_rutas
+    sobre una ruta arbitraria del usuario -- no hay una ubicación fija que
+    añadir a protection.py, así que la verja necesitaba el eje por nombre
+    para no vaciar este comando en silencio."""
+    from disk_analyzer import DiskAnalyzer
+
+    analyzer = DiskAnalyzer('.')
+    home = os.path.expanduser('~')
+    dir_path = f'{home}/Documents/repos/proyecto-abandonado/node_modules'
+    analyzer.directory_sizes[dir_path] = 300 * MB
+    # Sin .git/HEAD ni package.json en el padre -> se considera huérfano.
+
+    recs = {r['id']: r for r in analyzer.detect_smart_recommendations()}
+    assert 'node_modules_huerfano' in recs
+    cmd = recs['node_modules_huerfano']['command']
+    assert cmd.strip(), "el comando salió vacío: la verja bloqueó la ruta"
+    assert dir_path in cmd
+
+
+# -- Ronda de arreglo 1, punto 2: la red de seguridad genérica. Si la verja
+# bloquea TODAS las rutas de una regla, la recomendación entera tiene que
+# desaparecer -- no quedarse en la lista con 'command': "", que es un botón
+# que promete espacio y no hace nada. --
+
+def test_una_regla_totalmente_bloqueada_por_la_verja_no_aparece():
+    """Si protection.puede_borrarse descarta todas las rutas que una regla
+    junta, generate_recommendations() no debe devolver esa recomendación con
+    comando vacío: tiene que desaparecer de la lista por completo."""
+    ruta_prohibida = os.path.expanduser('~/Documents')
+    core = _core_con([
+        {'type': cache_types.LOGS, 'path': ruta_prohibida, 'size': 50 * MB},
+    ])
+    recs = {r['id']: r for r in core.generate_recommendations()}
+    assert 'logs' not in recs, (
+        "la regla 'logs' apareció con una ruta que la verja debería haber "
+        "descartado por completo -- si esto es intencional, contradice la "
+        "garantía de que ninguna recomendación sale con 'command' vacío"
+    )
+
+
+def test_ninguna_recomendacion_del_core_sale_con_comando_vacio():
+    """Red de seguridad genérica, sin depender de una regla concreta: para
+    cualquier estado sintético razonable, cada recomendación que sale de
+    generate_recommendations() tiene un 'command' no vacío."""
+    core = _core_con([
+        {'type': cache_types.LOGS, 'path': os.path.expanduser('~/Documents'), 'size': 50 * MB},
+        {'type': cache_types.GENERAL, 'path': os.path.expanduser('~/Library/Caches'), 'size': 21 * GB},
+        {'type': cache_types.TRASH, 'path': os.path.expanduser('~/.Trash'), 'size': 3 * GB},
+    ], docker={'available': True, 'reclaimable': 5 * GB})
+    for r in core.generate_recommendations():
+        assert (r.get('command') or '').strip(), (
+            f"{r['id']!r} salió con 'command' vacío"
+        )

--- a/web/src/components/CleanupWizard.tiers.test.tsx
+++ b/web/src/components/CleanupWizard.tiers.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { nivelDe } from './CleanupWizard';
+
+describe('nivelDe', () => {
+  it('respeta el nivel cuando viene', () => {
+    expect(nivelDe({ tier: 1 })).toBe(1);
+    expect(nivelDe({ tier: 3 })).toBe(3);
+  });
+
+  it('trata lo desconocido como lo más restrictivo, no como Seguro', () => {
+    for (const rec of [{}, { tier: undefined }, { tier: null }, { tier: 0 },
+                       { tier: NaN }, { tier: 'dos' }, { tier: 9 }]) {
+      expect(nivelDe(rec as any)).toBe(4);
+    }
+  });
+});

--- a/web/src/components/CleanupWizard.tiers.test.tsx
+++ b/web/src/components/CleanupWizard.tiers.test.tsx
@@ -1,11 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { render, cleanup, waitFor, screen, fireEvent } from '@testing-library/react';
 import { act } from '@testing-library/react';
 import { nivelDe } from './CleanupWizard';
 import CleanupWizard from './CleanupWizard';
+import { useCleanupRunner } from '../hooks/useCleanupRunner';
+
+const mockRun = vi.fn();
 
 vi.mock('../hooks/useCleanupRunner', () => ({
-  useCleanupRunner: vi.fn(() => ({ run: vi.fn(), running: new Set(), completed: new Set() })),
+  useCleanupRunner: vi.fn(() => ({ run: mockRun, running: new Set(), completed: new Set() })),
 }));
 
 describe('nivelDe', () => {
@@ -31,11 +34,8 @@ describe('CleanupWizard component: malformed recommendations', () => {
     cleanup();
   });
 
-  it('does not count malformed recommendations as safe', async () => {
-    // One legitimate tier-1 recommendation (100 bytes)
-    // Three malformed recommendations: no tier, tier: null, tier: 0 (100 bytes each)
-    // Without the fix, all four would be treated as tier 1 (total 400)
-    // With the fix, only the legitimate one counts (total 100)
+  it('safeTotalSpace does not include malformed recommendations', async () => {
+    // Verifies line 50: safeTotalSpace calculation. Observable in button label without clicking.
     const recs = [
       { description: 'Safe item', command: 'rm x', space: 100, tier: 1, priority: 'low', type: 'cache' },
       { description: 'Malformed (no tier)', command: 'rm y', space: 100, priority: 'low', type: 'cache' },
@@ -45,40 +45,102 @@ describe('CleanupWizard component: malformed recommendations', () => {
 
     render(<CleanupWizard />);
 
-    // Emit the analysis:completed event with mixed recommendations
     act(() => {
       window.dispatchEvent(new CustomEvent('analysis:completed', {
-        detail: {
-          results: [
-            { report: { recommendations: recs } },
-          ],
-        },
+        detail: { results: [{ report: { recommendations: recs } }] },
       }));
     });
 
-    // Wait for recommendations to be rendered
     await waitFor(
       () => {
-        const allText = document.body.textContent || '';
-        // This will throw if not found, which is what waitFor expects
-        if (!allText.includes('Safe item')) {
+        if (!document.body.textContent?.includes('Safe item')) {
           throw new Error('Safe item not found');
         }
       },
       { timeout: 2000 }
     );
 
-    // Get all text for verification
+    // The "Clean Safe Items" button should show "(100 B)" not "(400 B)"
+    // This protects line 50: safeTotalSpace = recs.filter(r => nivelDe(r) === 1)...
+    const buttonText = screen.getByText(/Clean Safe Items/).textContent;
+    expect(buttonText).toContain('(100 B)');
+    expect(buttonText).not.toContain('(400 B)');
+  });
+
+  it('cleanSafeItems only executes legitimate safe recommendations', async () => {
+    // Verifies line 53: safeRecs filtering in cleanSafeItems(). Protects what actually gets deleted.
+    // This is the critical path: line 53 decides what run() gets called with.
+    const recs = [
+      { description: 'Safe item', command: 'rm x', space: 100, tier: 1, priority: 'low', type: 'cache' },
+      { description: 'Malformed (no tier)', command: 'rm y', space: 100, priority: 'low', type: 'cache' },
+      { description: 'Malformed (null)', command: 'rm z', space: 100, tier: null as any, priority: 'low', type: 'cache' },
+      { description: 'Malformed (0)', command: 'rm w', space: 100, tier: 0, priority: 'low', type: 'cache' },
+    ] as any;
+
+    render(<CleanupWizard />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('analysis:completed', {
+        detail: { results: [{ report: { recommendations: recs } }] },
+      }));
+    });
+
+    await waitFor(
+      () => {
+        if (!document.body.textContent?.includes('Safe item')) {
+          throw new Error('Safe item not found');
+        }
+      },
+      { timeout: 2000 }
+    );
+
+    // Click the "Clean Safe Items" button
+    const button = screen.getByText(/Clean Safe Items/);
+    fireEvent.click(button);
+
+    // run() should be called exactly once (only for the legitimate safe recommendation)
+    // If line 53 were using r.tier || 1, it would call run() 4 times
+    expect(mockRun).toHaveBeenCalledTimes(1);
+    expect(mockRun).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'rm x',
+        space: 100,
+        label: 'Safe item',
+      })
+    );
+  });
+
+  it('does not count malformed recommendations as safe (visual grouping)', async () => {
+    // Verifies line 63: tier assignment for visual grouping. Less critical but good to have.
+    const recs = [
+      { description: 'Safe item', command: 'rm x', space: 100, tier: 1, priority: 'low', type: 'cache' },
+      { description: 'Malformed (no tier)', command: 'rm y', space: 100, priority: 'low', type: 'cache' },
+      { description: 'Malformed (null)', command: 'rm z', space: 100, tier: null as any, priority: 'low', type: 'cache' },
+      { description: 'Malformed (0)', command: 'rm w', space: 100, tier: 0, priority: 'low', type: 'cache' },
+    ] as any;
+
+    render(<CleanupWizard />);
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent('analysis:completed', {
+        detail: { results: [{ report: { recommendations: recs } }] },
+      }));
+    });
+
+    await waitFor(
+      () => {
+        if (!document.body.textContent?.includes('Safe item')) {
+          throw new Error('Safe item not found');
+        }
+      },
+      { timeout: 2000 }
+    );
+
     const allText = document.body.textContent || '';
 
-    // Verify Tier 1 has exactly 1 item and 100 B (not 4 items and 400 B)
+    // Verify visual grouping is correct
     expect(allText).toContain('1 items · 100 B');
-
-    // Verify Tier 4 has exactly 3 items and 300 B
     expect(allText).toContain('3 items · 300 B');
-
-    // Most importantly: verify that there is no "4 items · 400 B" which would indicate
-    // all recommendations were counted as Tier 1 due to the bug (r.tier || 1)
     expect(allText).not.toContain('4 items · 400 B');
   });
 });

--- a/web/src/components/CleanupWizard.tiers.test.tsx
+++ b/web/src/components/CleanupWizard.tiers.test.tsx
@@ -1,5 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, cleanup, waitFor } from '@testing-library/react';
+import { act } from '@testing-library/react';
 import { nivelDe } from './CleanupWizard';
+import CleanupWizard from './CleanupWizard';
+
+vi.mock('../hooks/useCleanupRunner', () => ({
+  useCleanupRunner: vi.fn(() => ({ run: vi.fn(), running: new Set(), completed: new Set() })),
+}));
 
 describe('nivelDe', () => {
   it('respeta el nivel cuando viene', () => {
@@ -12,5 +19,66 @@ describe('nivelDe', () => {
                        { tier: NaN }, { tier: 'dos' }, { tier: 9 }]) {
       expect(nivelDe(rec as any)).toBe(4);
     }
+  });
+});
+
+describe('CleanupWizard component: malformed recommendations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not count malformed recommendations as safe', async () => {
+    // One legitimate tier-1 recommendation (100 bytes)
+    // Three malformed recommendations: no tier, tier: null, tier: 0 (100 bytes each)
+    // Without the fix, all four would be treated as tier 1 (total 400)
+    // With the fix, only the legitimate one counts (total 100)
+    const recs = [
+      { description: 'Safe item', command: 'rm x', space: 100, tier: 1, priority: 'low', type: 'cache' },
+      { description: 'Malformed (no tier)', command: 'rm y', space: 100, priority: 'low', type: 'cache' },
+      { description: 'Malformed (null)', command: 'rm z', space: 100, tier: null as any, priority: 'low', type: 'cache' },
+      { description: 'Malformed (0)', command: 'rm w', space: 100, tier: 0, priority: 'low', type: 'cache' },
+    ] as any;
+
+    render(<CleanupWizard />);
+
+    // Emit the analysis:completed event with mixed recommendations
+    act(() => {
+      window.dispatchEvent(new CustomEvent('analysis:completed', {
+        detail: {
+          results: [
+            { report: { recommendations: recs } },
+          ],
+        },
+      }));
+    });
+
+    // Wait for recommendations to be rendered
+    await waitFor(
+      () => {
+        const allText = document.body.textContent || '';
+        // This will throw if not found, which is what waitFor expects
+        if (!allText.includes('Safe item')) {
+          throw new Error('Safe item not found');
+        }
+      },
+      { timeout: 2000 }
+    );
+
+    // Get all text for verification
+    const allText = document.body.textContent || '';
+
+    // Verify Tier 1 has exactly 1 item and 100 B (not 4 items and 400 B)
+    expect(allText).toContain('1 items · 100 B');
+
+    // Verify Tier 4 has exactly 3 items and 300 B
+    expect(allText).toContain('3 items · 300 B');
+
+    // Most importantly: verify that there is no "4 items · 400 B" which would indicate
+    // all recommendations were counted as Tier 1 due to the bug (r.tier || 1)
+    expect(allText).not.toContain('4 items · 400 B');
   });
 });

--- a/web/src/components/CleanupWizard.tiers.test.tsx
+++ b/web/src/components/CleanupWizard.tiers.test.tsx
@@ -3,7 +3,6 @@ import { render, cleanup, waitFor, screen, fireEvent } from '@testing-library/re
 import { act } from '@testing-library/react';
 import { nivelDe } from './CleanupWizard';
 import CleanupWizard from './CleanupWizard';
-import { useCleanupRunner } from '../hooks/useCleanupRunner';
 
 const mockRun = vi.fn();
 
@@ -18,8 +17,23 @@ describe('nivelDe', () => {
   });
 
   it('trata lo desconocido como lo más restrictivo, no como Seguro', () => {
-    for (const rec of [{}, { tier: undefined }, { tier: null }, { tier: 0 },
-                       { tier: NaN }, { tier: 'dos' }, { tier: 9 }]) {
+    // Rechaza: undefined, null, 0, NaN, no-integers, strings, booleans, arrays, objetos
+    for (const rec of [
+      {},
+      { tier: undefined },
+      { tier: null },
+      { tier: 0 },
+      { tier: NaN },
+      { tier: 'dos' },
+      { tier: '1' },           // string, not number
+      { tier: 9 },             // out of range
+      { tier: true },          // boolean - Number(true)===1 is the bug we fix
+      { tier: false },         // boolean - Number(false)===0
+      { tier: [1] },           // array - Number([1])===1 is also a bug
+      { tier: ['1'] },         // array of string
+      { tier: 2.5 },           // non-integer number
+      { tier: {} },            // object
+    ]) {
       expect(nivelDe(rec as any)).toBe(4);
     }
   });

--- a/web/src/components/CleanupWizard.tsx
+++ b/web/src/components/CleanupWizard.tsx
@@ -12,10 +12,13 @@ import { TIER_META } from '../lib/tiers';
  * El código anterior hacía `r.tier || 1`, que convertía `undefined`, `null` y
  * `0` en Seguro — y Seguro es justo lo que el botón de "ejecutar todo" lanza
  * sin revisión. Ante una recomendación malformada, lo correcto es lo contrario.
+ *
+ * Verifica el tipo ANTES de coercionar. Rechaza: booleans (Number(true)===1),
+ * arrays (Number([1])===1), strings ("1" !== 1), y números no-enteros.
  */
 export function nivelDe(rec: { tier?: unknown }): number {
-  const n = Number(rec?.tier);
-  return Number.isInteger(n) && n >= 1 && n <= 4 ? n : 4;
+  const n = rec?.tier;
+  return typeof n === 'number' && Number.isInteger(n) && n >= 1 && n <= 4 ? n : 4;
 }
 
 export default function CleanupWizard() {

--- a/web/src/components/CleanupWizard.tsx
+++ b/web/src/components/CleanupWizard.tsx
@@ -5,6 +5,19 @@ import { formatBytes } from '../lib/format';
 import { useCleanupRunner } from '../hooks/useCleanupRunner';
 import { TIER_META } from '../lib/tiers';
 
+/**
+ * El nivel de riesgo de una recomendación, o el más restrictivo si no se
+ * puede saber.
+ *
+ * El código anterior hacía `r.tier || 1`, que convertía `undefined`, `null` y
+ * `0` en Seguro — y Seguro es justo lo que el botón de "ejecutar todo" lanza
+ * sin revisión. Ante una recomendación malformada, lo correcto es lo contrario.
+ */
+export function nivelDe(rec: { tier?: unknown }): number {
+  const n = Number(rec?.tier);
+  return Number.isInteger(n) && n >= 1 && n <= 4 ? n : 4;
+}
+
 export default function CleanupWizard() {
   const [recs, setRecs] = useState<Recommendation[]>([]);
   const [expanded, setExpanded] = useState<Set<number>>(new Set([1]));
@@ -34,20 +47,20 @@ export default function CleanupWizard() {
   };
 
   const totalRecoverable = recs.reduce((s, r) => s + (r.space || 0), 0);
-  const safeTotalSpace = recs.filter(r => (r.tier || 1) === 1).reduce((s, r) => s + (r.space || 0), 0);
+  const safeTotalSpace = recs.filter(r => nivelDe(r) === 1).reduce((s, r) => s + (r.space || 0), 0);
 
   const cleanSafeItems = () => {
-    const safeRecs = recs.filter(r => (r.tier || 1) === 1 && r.command && !r.command.startsWith('#'));
+    const safeRecs = recs.filter(r => nivelDe(r) === 1 && r.command && !r.command.startsWith('#'));
     for (const rec of safeRecs) {
       run({ command: rec.command, space: rec.space, label: rec.description });
     }
   };
 
-  const safeRecsRunnable = recs.filter(r => (r.tier || 1) === 1 && r.command && !r.command.startsWith('#'));
+  const safeRecsRunnable = recs.filter(r => nivelDe(r) === 1 && r.command && !r.command.startsWith('#'));
   const safeRunning = safeRecsRunnable.some(r => running.has(r.command));
 
   const grouped = recs.reduce((acc, rec) => {
-    const tier = rec.tier || 1;
+    const tier = nivelDe(rec);
     if (!acc[tier]) acc[tier] = [];
     acc[tier].push(rec);
     return acc;

--- a/web/src/hooks/useCleanupRunner.test.ts
+++ b/web/src/hooks/useCleanupRunner.test.ts
@@ -384,4 +384,90 @@ describe('useCleanupRunner', () => {
 
     expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 42, estimado: 42 }));
   });
+
+  it('si la medición "antes" va bien pero "después" falla, cae al estimado', async () => {
+    mockedGetSystemInfo
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any)
+      .mockRejectedValueOnce(new Error('offline'));
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: 'rm -rf x', space: 20 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 20, estimado: 20 }));
+  });
+
+  it('si la medición "antes" falla, no se intenta medir "después" y cae al estimado', async () => {
+    mockedGetSystemInfo.mockRejectedValueOnce(new Error('offline'));
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: 'rm -rf x', space: 15 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 15, estimado: 15 }));
+    // libreAntes quedó en null, así que finishActiveJob nunca intenta la
+    // segunda medición — solo se llamó a getSystemInfo una vez.
+    expect(mockedGetSystemInfo).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Fix round 6: la medición no puede colgar la cola ─────────────────────
+  //
+  // request() (web/src/lib/api.ts) no tiene timeout ni AbortController: un
+  // servidor que acepta la conexión y nunca responde (ocupado con un scan,
+  // por ejemplo) dejaría el await de la medición sin resolver para siempre.
+  // conLimite() acota ambas mediciones a MEASURE_TIMEOUT_MS (3000ms aquí)
+  // para que ese escenario caiga al estimado en vez de colgar la cola.
+
+  it('si la medición "antes" se cuelga, expira y no bloquea la cola', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockedGetSystemInfo.mockImplementationOnce(() => new Promise(() => { /* never resolves */ }));
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+
+    const { result } = renderHook(() => useCleanupRunner());
+    act(() => { result.current.run({ command: 'rm -rf x', space: 7 }); });
+
+    // La medición "antes" nunca resuelve — avanza más allá de su propio
+    // límite para que startJob() pueda seguir y crear el terminal.
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+    act(() => { emit('terminal:exited', { pty_id: 'pty-1', code: 0 }); });
+    await waitFor(() => expect(visto).toHaveBeenCalled());
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 7, estimado: 7 }));
+
+    vi.useRealTimers();
+  });
+
+  it('si la medición "después" se cuelga, expira, credita el estimado y la cola sigue', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    mockedGetSystemInfo
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any) // "antes" ok
+      .mockImplementationOnce(() => new Promise(() => { /* never resolves */ })); // "después" se cuelga
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+
+    const { result } = renderHook(() => useCleanupRunner());
+    act(() => { result.current.run({ command: 'rm -rf x', space: 9 }); });
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+
+    act(() => { emit('terminal:exited', { pty_id: 'pty-1', code: 0 }); });
+
+    // La medición "después" nunca resuelve — avanza más allá de su límite
+    // para que se acredite en vez de quedarse colgado para siempre.
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000); });
+
+    await waitFor(() => expect(visto).toHaveBeenCalled());
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 9, estimado: 9 }));
+
+    // La cola no quedó atascada: un trabajo encolado detrás sigue pudiendo arrancar.
+    mockedGetSystemInfo.mockRejectedValue(new Error('offline'));
+    act(() => { result.current.run({ command: 'rm -rf y', space: 3 }); });
+    await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(2));
+
+    vi.useRealTimers();
+  });
 });

--- a/web/src/hooks/useCleanupRunner.test.ts
+++ b/web/src/hooks/useCleanupRunner.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useCleanupRunner, __resetCleanupRunnerForTests } from './useCleanupRunner';
-import { emit } from '../lib/events';
+import { emit, on } from '../lib/events';
 import { api } from '../lib/api';
 
 vi.mock('../lib/api', () => ({
-  api: { createTerminal: vi.fn() },
+  api: { createTerminal: vi.fn(), getSystemInfo: vi.fn() },
 }));
 
 const mockedCreate = vi.mocked(api.createTerminal);
+const mockedGetSystemInfo = vi.mocked(api.getSystemInfo);
 
 beforeEach(() => {
   localStorage.clear();
@@ -16,7 +17,25 @@ beforeEach(() => {
   vi.useRealTimers();
   __resetCleanupRunnerForTests();
   mockedCreate.mockResolvedValue({ pty_id: 'pty-1', created_at: '2026-01-01T00:00:00Z' } as any);
+  // Default: the disk measurement is unavailable, so completed jobs fall
+  // back to the recommendation's own estimate — this is what every test
+  // below that doesn't care about disk measurement relies on. Tests that
+  // do care override this per-call with mockResolvedValueOnce.
+  mockedGetSystemInfo.mockRejectedValue(new Error('getSystemInfo not mocked in this test'));
 });
+
+/**
+ * Queue `job`, let it start (mockedCreate always resolves to pty-1 unless a
+ * test overrides it), fire its exit with `code`, and wait for the queue to
+ * settle before returning.
+ */
+async function ejecutarYCompletar(job: { command: string; space: number }, code: number): Promise<void> {
+  const { result } = renderHook(() => useCleanupRunner());
+  act(() => { result.current.run(job); });
+  await waitFor(() => expect(mockedCreate).toHaveBeenCalledTimes(1));
+  act(() => { emit('terminal:exited', { pty_id: 'pty-1', code }); });
+  await waitFor(() => expect(result.current.running.has(job.command)).toBe(false));
+}
 
 describe('useCleanupRunner', () => {
   it('credits the saving only after the command exits with code 0', async () => {
@@ -307,5 +326,62 @@ describe('useCleanupRunner', () => {
     await waitFor(() => expect(result.current.completed.has('next-cmd')).toBe(true));
 
     vi.useRealTimers();
+  });
+
+  // ── Fix round 5: credit what the disk shows, not the exit code ──────────
+  //
+  // Crediting savings off the exit code is what let a no-op command report
+  // "85 MB liberados". `rm -f` returns 0 whether it deleted everything or
+  // nothing — the exit code proves nothing about space. Only the disk does.
+
+  it('acredita el espacio realmente liberado, no el estimado', async () => {
+    // libre antes: 10 GB; después: 12 GB  →  se liberaron 2 GB
+    mockedGetSystemInfo
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any)
+      .mockResolvedValueOnce({ disk_usage: { free: 12e9 } } as any);
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: 'rm -rf x', space: 99e9 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(
+      expect.objectContaining({ space: 2e9, estimado: 99e9 }),
+    );
+  });
+
+  it('un comando que no libera nada acredita cero, no su estimación', async () => {
+    mockedGetSystemInfo
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any)
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any);
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: "rm -rf 'x/*'", space: 85e6 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 0 }));
+  });
+
+  it('nunca acredita un ahorro negativo', async () => {
+    // Otro proceso escribió mientras corría la limpieza.
+    mockedGetSystemInfo
+      .mockResolvedValueOnce({ disk_usage: { free: 12e9 } } as any)
+      .mockResolvedValueOnce({ disk_usage: { free: 10e9 } } as any);
+
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: 'rm -rf x', space: 1e9 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 0 }));
+  });
+
+  it('si getSystemInfo falla, cae al espacio estimado sin romper la cola', async () => {
+    // Ambas llamadas (antes y después) fallan — comportamiento por defecto
+    // del beforeEach de este archivo. La limpieza debe seguir acreditándose
+    // con la estimación, no quedar colgada ni lanzar.
+    const visto = vi.fn();
+    on('cleanup:completed', visto);
+    await ejecutarYCompletar({ command: 'rm -rf x', space: 42 }, 0);
+
+    expect(visto).toHaveBeenCalledWith(expect.objectContaining({ space: 42, estimado: 42 }));
   });
 });

--- a/web/src/hooks/useCleanupRunner.ts
+++ b/web/src/hooks/useCleanupRunner.ts
@@ -13,6 +13,28 @@ const STORAGE_KEY = 'disk-analyzer-cleaned';
 // a genuinely stuck queue recovers within one page visit.
 const STUCK_JOB_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
 
+// The disk-space measurement must never hang the queue. `request()` (see
+// web/src/lib/api.ts) has no timeout or AbortController, so a server that
+// accepts the connection and never responds — busy with a scan, say — would
+// leave that await unresolved forever. In startJob() this happens before the
+// watchdog above is even armed (it's only set once createTerminal resolves);
+// in finishActiveJob() the watchdog for the job that just exited has already
+// been cleared. A few seconds is plenty for a call to localhost; if we don't
+// hear back in time, fall back to the estimate — the same outcome as any
+// other measurement failure.
+const MEASURE_TIMEOUT_MS = 3000;
+
+/** Race `p` against a timeout, resolving to `null` (never rejecting) if the timeout wins. */
+function conLimite<T>(p: Promise<T>, ms: number): Promise<T | null> {
+  return new Promise<T | null>(resolve => {
+    const timer = setTimeout(() => resolve(null), ms);
+    p.then(
+      v => { clearTimeout(timer); resolve(v); },
+      () => { clearTimeout(timer); resolve(null); },
+    );
+  });
+}
+
 export interface CleanupJob {
   command: string;
   space: number;
@@ -135,9 +157,10 @@ async function startJob(job: CleanupJob): Promise<void> {
   // reflects what the command actually freed instead of trusting its
   // estimate. Stored on the job itself (not a module variable) since several
   // jobs pass through this queue over the page's lifetime.
-  const libreAntes = await api.getSystemInfo()
-    .then(i => i.disk_usage?.free ?? null)
-    .catch(() => null);
+  const libreAntes = await conLimite(
+    api.getSystemInfo().then(i => i.disk_usage?.free ?? null),
+    MEASURE_TIMEOUT_MS,
+  );
   const queuedJob: QueuedJob = { ...job, libreAntes };
   try {
     const { pty_id } = await api.createTerminal(job.command);
@@ -194,9 +217,10 @@ async function finishActiveJob(ptyId: string, code: number | null): Promise<void
     // measurement itself isn't available.
     let liberado = job.space;
     if (job.libreAntes != null) {
-      const libreDespues = await api.getSystemInfo()
-        .then(i => i.disk_usage?.free ?? null)
-        .catch(() => null);
+      const libreDespues = await conLimite(
+        api.getSystemInfo().then(i => i.disk_usage?.free ?? null),
+        MEASURE_TIMEOUT_MS,
+      );
       if (libreDespues != null) {
         // Another process can write to disk while cleanup runs; never
         // credit a negative saving.

--- a/web/src/hooks/useCleanupRunner.ts
+++ b/web/src/hooks/useCleanupRunner.ts
@@ -19,6 +19,16 @@ export interface CleanupJob {
   label?: string;
 }
 
+// Internal, queue-only shape: adds the free-space measurement taken right
+// before the command started. Kept out of the public CleanupJob so callers
+// of run() never have to supply it — it's captured by startJob() itself and
+// carried on the job object (not a module-level variable) because several
+// jobs can be in flight in the queue over time and a shared variable would
+// get clobbered between them.
+interface QueuedJob extends CleanupJob {
+  libreAntes: number | null;
+}
+
 export interface CleanupRunner {
   /** Enqueue the command to run in a PTY once any prior queued command has resolved. */
   run: (job: CleanupJob) => void;
@@ -101,7 +111,7 @@ function getServerSnapshot(): CleanupState {
 // this module starts at most one command at a time, crediting (or failing)
 // each before starting the next.
 const queue: CleanupJob[] = [];
-const jobs: Record<string, CleanupJob> = {}; // pty_id -> the one active job, while one is in flight
+const jobs: Record<string, QueuedJob> = {}; // pty_id -> the one active job, while one is in flight
 let processing = false;
 let watchdog: ReturnType<typeof setTimeout> | null = null;
 
@@ -121,9 +131,17 @@ function scheduleNext(): void {
 }
 
 async function startJob(job: CleanupJob): Promise<void> {
+  // Measure free disk space before the command runs, so the eventual credit
+  // reflects what the command actually freed instead of trusting its
+  // estimate. Stored on the job itself (not a module variable) since several
+  // jobs pass through this queue over the page's lifetime.
+  const libreAntes = await api.getSystemInfo()
+    .then(i => i.disk_usage?.free ?? null)
+    .catch(() => null);
+  const queuedJob: QueuedJob = { ...job, libreAntes };
   try {
     const { pty_id } = await api.createTerminal(job.command);
-    jobs[pty_id] = job;
+    jobs[pty_id] = queuedJob;
     emit('terminal:open', { pty_id, command: job.command });
     watchdog = setTimeout(() => giveUpOn(pty_id), STUCK_JOB_TIMEOUT_MS);
   } catch (e: any) {
@@ -150,7 +168,7 @@ function giveUpOn(ptyId: string): void {
   scheduleNext();
 }
 
-function finishActiveJob(ptyId: string, code: number | null): void {
+async function finishActiveJob(ptyId: string, code: number | null): Promise<void> {
   const job = jobs[ptyId];
   // An exit for a pty this module isn't tracking — either something
   // unrelated (a manually opened shell) or a duplicate event for a job
@@ -169,7 +187,23 @@ function finishActiveJob(ptyId: string, code: number | null): void {
     const nextCompleted = new Set(state.completed).add(job.command);
     persist(nextCompleted);
     setState({ running: nextRunning, completed: nextCompleted });
-    emit('cleanup:completed', { command: job.command, space: job.space });
+
+    // The exit code proves nothing about the space freed: `rm -f` returns 0
+    // whether it deleted everything or nothing. Measure the disk instead,
+    // and only fall back to the recommendation's own estimate when the
+    // measurement itself isn't available.
+    let liberado = job.space;
+    if (job.libreAntes != null) {
+      const libreDespues = await api.getSystemInfo()
+        .then(i => i.disk_usage?.free ?? null)
+        .catch(() => null);
+      if (libreDespues != null) {
+        // Another process can write to disk while cleanup runs; never
+        // credit a negative saving.
+        liberado = Math.max(0, libreDespues - job.libreAntes);
+      }
+    }
+    emit('cleanup:completed', { command: job.command, space: liberado, estimado: job.space });
   } else {
     setState({ running: nextRunning, error: `${job.label ?? job.command} exited with code ${code}` });
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -80,6 +80,10 @@ export interface Recommendation {
   description: string;
   space: number;
   command: string;
+  /** Qué hace realmente el comando. Opcional: los informes viejos no lo traen. */
+  efecto?: 'borra' | 'irreversible' | 'solo_lista';
+  /** Identificador estable, ver Task 6. Opcional por la misma razón. */
+  id?: string;
 }
 
 export interface AnalysisReport {


### PR DESCRIPTION
Este trabajo nació al planear un botón de "liberar lo seguro" para el menú de la barra. Cinco revisiones adversariales sobre esa propuesta encontraron que la maquinaria de limpieza tenía defectos serios, así que el botón se aplazó y se saneó la base primero. **Construir un botón de un clic encima de una inyección de shell era el orden equivocado.**

## Lo que estaba roto

Los cinco, reproducidos antes de escribir una línea de plan:

- **Inyección de shell.** Las rutas se interpolaban sin escapar en cadenas que se ejecutan con `sh -c`. Una carpeta llamada `x' ; rm -rf victim ; touch pwned '` generaba tres comandos encadenados: reproducido borrando una carpeta ajena y ejecutando código arbitrario. La ruta la aporta el escaneo del disco, así que basta un zip con un nombre hostil. Bajo `sudo make web`, como root.
- **Limpiezas que no limpiaban.** El glob iba *dentro* de las comillas: `rm -rf 'dir/*'` sale con código 0 y no toca nada. Y la interfaz acreditaba el ahorro al ver ese 0. Pulsabas "limpiar logs", te decía "85 MB liberados", y no se borraba un byte.
- **`make clean-cache` borraba `~/Downloads` según cómo te llamaras.** El clasificador busca subcadenas en la ruta completa, nombre de usuario incluido: un usuario `logan` veía su carpeta de Descargas clasificada como logs del sistema, y se borraba permanentemente, sin papelera. Con un comentario en el propio código que decía *"NUNCA Downloads"*.
- **La protección no protegía tus datos.** `~/Documents`, `~/Desktop`, iCloud Drive, `/Volumes/Backup Time Machine` y tu propio `$HOME` salían como borrables. Era una lista negra del sistema operativo, no una whitelist de lo que se puede borrar.
- **La app de bandeja abría lo que hubiera en el puerto 8000** presentándolo como el analizador.

## Lo que deja

Además de los arreglos, cuatro cimientos:

- **Una verja de borrado** (`puede_borrarse`) instalada en los tres caminos que borran — el generador de comandos, el `clean_cache` de la CLI y el endpoint de la web. Resiste mayúsculas (APFS no distingue caja), enlaces simbólicos, `..` y rutas relativas.
- **Un `id` estable y un campo `efecto`** por recomendación: `borra`, `irreversible` o `solo_lista`. Resultó que **tres de nueve reglas no borraban nada** y una tenía como comando un comentario de shell.
- **Una sola definición de los niveles de riesgo.** Había dos copias ya divergidas: la web usaba una y la app de bandeja la otra.
- **El ahorro medido del disco**, no deducido del código de salida.

## Lo que salió al revisar, y no lo habría cazado ningún test

**Un refactor de deduplicación llegó a borrar builds firmadas.** Al mover una regla al motor compartido se la "hizo consistente" con el patrón de las demás — que filtra por tipo de caché. Como `DerivedData` y `Archives` clasifican igual, la regla pasó a borrar los `.xcarchive`: builds firmadas y dSYM para simbolicar crashes de versiones publicadas, que no se regeneran nunca. Con una descripción que decía *"se regeneran al compilar"*. Los 211 tests estaban en verde.

De ahí salió la norma que ahora está en `CLAUDE.md`: **ninguna regla filtra por tipo de caché a secas; siempre se acota además por ruta.**

**Y nueve tests pasaban por la razón equivocada.** Uno sobrevivía a que le quitaras el filtro que existe para proteger. Otro cubría la agrupación visual creyendo cubrir el camino de ejecución. Tres escaneaban el disco real y pasaban aunque no encontraran nada.

## Verificación

- **352 tests**: 247 backend, 85 frontend, 20 Rust. Clippy limpio.
- La suite de backend pasó de **70,9 s a 5,65 s** — tres tests escaneaban el disco entero en cada ejecución.
- **Verificación manual del puerto**, hecha a mano: con un `python3 -m http.server` ocupando el 8000, la app arrancó su servidor en el 56755, abrió el navegador ahí y dejó al intruso intacto.
- Cada arreglo verificado **revirtiéndolo** para comprobar que su test cae.

## Lo que queda fuera, a propósito

El campo `efecto` está construido y ningún componente lo lee todavía. El número de cabecera sigue sumando cachés que nunca se ofrecen. Dos reglas no pueden dispararse nunca porque sus rutas están en `IGNORE_PATTERNS`. Y el botón que originó todo esto sigue sin existir. Todo ello anotado en `docs/superpowers/plans/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)